### PR TITLE
Update to File widget for uploading multiple files

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "font-awesome": "^4.7.0",
     "history": "^5.1.0",
     "js-file-download": "^0.4.12",
+    "mercury": "rmkolany/mercury#multiple-files-widget"
     "popper": "^1.0.1",
     "react": "^17.0.2",
     "react-block-ui": "^1.3.5",

--- a/frontend/src/widgets/File.tsx
+++ b/frontend/src/widgets/File.tsx
@@ -31,6 +31,7 @@ type FileProps = {
   maxFileSize: string | null;
   disabled: boolean;
   hidden: boolean;
+  multiple: boolean;
   value: string[];
   runNb: () => void;
 };
@@ -41,6 +42,7 @@ export default function FileWidget({
   maxFileSize,
   disabled,
   hidden,
+  multiple,
   value,
   runNb,
 }: FileProps) {


### PR DESCRIPTION
Link to Issue #347 
To help move this issue along I updated the `File` widget to accept multiple files. I added an argument `multiple` to allow the user to specify if they would like to allow multiple files to be uploaded. `multiple=False` by default and should have no impact on users who are using this widget for one file now. `filename`, `filepath`, and `value` output lists if `multiple=True`. I considered using a different method but wanted to retain the current functionality as much as possible. 

### `File` Widget Use with Multiple Files
**Input**
`myFile = mercury.File(label="Upload File Here", multiple=True)`

**Handling Files After Upload**
`myFile.filename`

> ['file1_name.ext','file2_name.ext']

`myFile.filepath`

> ['path\\to\\files\\temp_dir\\file1_name.ext','path\\to\\files\\temp_dir\\file2name.ext']

`myFile.value`

> [<memory at 0x0000012345678910>,<memory at 0x0000010987654321>]

`myFile.temp_dir`

> 'path\\to\\files\\temp_dir'


I was able to get this to work in my environment without any issues in Jupyter Lab but the file uploader would not accept multiple files in the Mercury UI. It looks like some updates may be needed on the React side of things but I am not familiar with React to make the necessary changes.
