### PR TITLE
mercury data dir config setting; start celery with the initial python…

### DIFF
--- a/mercury/apps/storage/utils.py
+++ b/mercury/apps/storage/utils.py
@@ -14,7 +14,10 @@ if os.environ.get("STORAGE", STORAGE_MEDIA) == STORAGE_S3:
 from pathlib import Path
 
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
-MEDIA_ROOT = str(BASE_DIR / "media")
+
+MERCURY_DATA_DIR = Path(os.getenv('MERCURY_DATA_DIR', BASE_DIR))
+
+MEDIA_ROOT = str(MERCURY_DATA_DIR / "media")
 MEDIA_URL = "/media/"
 
 

--- a/mercury/mercury.py
+++ b/mercury/mercury.py
@@ -47,7 +47,6 @@ from widgets.in_mercury import in_mercury
 from widgets.user import user
 from widgets.pdf import PDF
 
-
 def print_version():
     try:
         mercury_version = ""
@@ -197,7 +196,10 @@ def main():
             or "runworker" in sys.argv
             or "--runworker" in sys.argv
         ):
+            py_executable = sys.executable
             worker_command = [
+                py_executable,
+                "-m",
                 "celery",
                 "-A",
                 "mercury.server" if sys.argv[0].endswith("mercury") else "server",
@@ -220,6 +222,8 @@ def main():
 
             # celery worker beat for periodic tasks
             beat_command = [
+                py_executable,
+                "-m",
                 "celery",
                 "-A",
                 "mercury.server" if sys.argv[0].endswith("mercury") else "server",

--- a/mercury/server/settings.py
+++ b/mercury/server/settings.py
@@ -1,5 +1,4 @@
 import os
-import sys
 from pathlib import Path
 
 from dotenv import load_dotenv
@@ -20,6 +19,8 @@ load_dotenv("../.env")
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
+MERCURY_DATA_DIR = Path(os.getenv('MERCURY_DATA_DIR', BASE_DIR))
+
 FRONTEND_BUILD_DIR = str(BASE_DIR / "frontend-dist")
 FRONTEND_STATIC_DIR = str(BASE_DIR / "frontend-dist" / "static")
 
@@ -28,12 +29,12 @@ STORAGE_S3 = "s3"
 STORAGE = STORAGE_MEDIA
 if os.environ.get("STORAGE", STORAGE_MEDIA) == STORAGE_S3:
     STORAGE = STORAGE_S3
-DJANGO_DRF_FILEPOND_UPLOAD_TMP = str(BASE_DIR / "uploads-temp")
-DJANGO_DRF_FILEPOND_FILE_STORE_PATH = str(BASE_DIR / "uploads")
+DJANGO_DRF_FILEPOND_UPLOAD_TMP = str(MERCURY_DATA_DIR / "uploads-temp")
+DJANGO_DRF_FILEPOND_FILE_STORE_PATH = str(MERCURY_DATA_DIR / "uploads")
 
 
-CELERY_BROKER_URL = os.environ.get("CELERY_BROKER_URL", "sqla+sqlite:///celery.sqlite")
-CELERY_RESULT_BACKEND = os.environ.get("CELERY_RESULT_BACKEND", "db+sqlite:///celery.sqlite")
+CELERY_BROKER_URL = os.environ.get("CELERY_BROKER_URL", f"sqla+sqlite:///{str(MERCURY_DATA_DIR)}/celery.sqlite")
+CELERY_RESULT_BACKEND = os.environ.get("CELERY_RESULT_BACKEND", f"db+sqlite:///{str(MERCURY_DATA_DIR)}/celery.sqlite")
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/3.2/howto/deployment/checklist/
@@ -177,7 +178,7 @@ DB_POSTGRESQL = "postgresql"
 DATABASES_ALL = {
     DB_SQLITE: {
         "ENGINE": "django.db.backends.sqlite3",
-        "NAME": BASE_DIR / "db.sqlite3",
+        "NAME": MERCURY_DATA_DIR / "db.sqlite3",
     },
     DB_POSTGRESQL: {
         "ENGINE": "django.db.backends.postgresql",
@@ -231,12 +232,12 @@ if DEBUG or SERVE_STATIC:
     STATIC_URL = "/static/"
     STATICFILES_DIRS = [FRONTEND_BUILD_DIR, FRONTEND_STATIC_DIR]
     if SERVE_STATIC:
-        STATIC_ROOT = str(BASE_DIR / "static")
+        STATIC_ROOT = str(MERCURY_DATA_DIR / "static")
 else:
     STATIC_URL = "/django_static/"
     STATIC_ROOT = str(BASE_DIR / "django_static")
 
-MEDIA_ROOT = str(BASE_DIR / "media")
+MEDIA_ROOT = str(MERCURY_DATA_DIR / "media")
 
 if not os.path.exists(MEDIA_ROOT):
     try:


### PR DESCRIPTION
Hi,

I would like to propose those changes since they fix the two issues that I raised in [Issue 384 DATA_DIR proposal](https://github.com/mljar/mercury/issues/384) and [Issue 390 Import Error](https://github.com/mljar/mercury/issues/390).

What are the code changes about:

I introduce a MERCURY_DATA_DIR variable that can be set by env. variable (using dotenv). I used MERCURY_DATA_DIR wherever I found that mercury created data in my testing. If MERCURY_DATA_DIR is not set it will fall back to BASE_DIR in order to keep the behavior of mercury as before.

Second change is about starting celery with the same python executable that was used to run mercury.