### PR TITLE
fix(dependencies): update django to 4.2.3

### DIFF
--- a/mercury/requirements.txt
+++ b/mercury/requirements.txt
@@ -1,4 +1,4 @@
-django==4.2.2
+django==4.2.3
 djangorestframework==3.14.0
 django-filter==21.1
 markdown==3.3.6


### PR DESCRIPTION
django<=4.2.2 has CVE-2023-36053. Allowing django to update resolves the CVE.

references:
- https://github.com/advisories/GHSA-jh3w-4vvf-mjgr