### PR TITLE
fix(dependencies): update django to 4.2.7

### DIFF
--- a/mercury/requirements.txt
+++ b/mercury/requirements.txt
@@ -1,4 +1,4 @@
-django==4.2.3
+django==4.2.7
 djangorestframework==3.14.0
 django-filter==21.1
 markdown==3.3.6


### PR DESCRIPTION
django<=4.2.7 has CVE-2023-46695. Allowing django to update resolves the CVE.

references:
https://github.com/advisories/GHSA-qmf9-6jqf-j8fq