### PR TITLE
fix(dependencies): update django to 4.2.13

### DIFF
--- a/mercury/requirements.txt
+++ b/mercury/requirements.txt
@@ -1,4 +1,4 @@
-django==4.2.7
+django==4.2.13
 djangorestframework==3.14.0
 django-filter==21.1
 markdown==3.3.6


### PR DESCRIPTION
- CVE-2024-24680 (patched in [4.2.10](https://docs.djangoproject.com/en/5.0/releases/4.2.10/))
- CVE-2024-27351 (patched in [4.2.11](https://docs.djangoproject.com/en/5.0/releases/4.2.11/))