### PR TITLE
Remove ipython_genutils

### DIFF
--- a/mercury/requirements.txt
+++ b/mercury/requirements.txt
@@ -6,7 +6,6 @@ celery>=5.1.2
 sqlalchemy==1.4.27
 gevent
 nbconvert>=7.8.0
-ipython_genutils
 django-cors-headers==3.10.1
 ipython>=7.30.1
 ipykernel>=6.6.0 


### PR DESCRIPTION
It should not be necessary and has been deprecated fro 7 years.  There should not be any dependency that uses it, if so then it should be fixed upstream. 

Keeping ipython_genutils  this is problematic as it depends on nose, which is not packaged in many distributions anymore; and we receive bug report.