### PR TITLE
update Dockerfile to streamline package installation and upgrade cele…

### DIFF
--- a/docker/mercury/Dockerfile
+++ b/docker/mercury/Dockerfile
@@ -23,11 +23,11 @@ ENV PATH="/opt/conda/bin:${PATH}"
 WORKDIR /app
 ADD ./mercury/requirements.txt /app/mercury/
 
+RUN conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main --channel https://repo.anaconda.com/pkgs/r
 RUN conda install --yes mamba -c conda-forge
-RUN mamba install --yes python=3.10 --file mercury/requirements.txt -c conda-forge
-RUN mamba install --yes gunicorn psycopg2 daphne -c conda-forge
-RUN mamba install --yes mercury -c conda-forge
-
+RUN mamba install --yes python=3.10 gunicorn psycopg2 daphne mercury -c conda-forge
+RUN mamba install --yes celery>=5.2 -c conda-forge
+RUN pip install -r mercury/requirements.txt
 ADD ./mercury/templates /app/mercury/templates
 ADD ./mercury/server /app/mercury/server
 ADD ./mercury/apps /app/mercury/apps

--- a/mercury/requirements.txt
+++ b/mercury/requirements.txt
@@ -2,7 +2,7 @@ django==4.2.7
 djangorestframework==3.14.0
 django-filter==21.1
 markdown==3.3.6
-celery>=5.1.2
+celery>=5.2
 sqlalchemy==1.4.27
 gevent
 nbconvert>=7.8.0


### PR DESCRIPTION
I ran into these errors and I might have fixed it with this commit. open to suggestions for improvement.

Errors:

```
CondaToSNonInteractiveError: Terms of Service have not been accepted for the following channels. Please accept or remove them before proceeding:                                                                                 
1.444     • https://repo.anaconda.com/pkgs/main                                                                                                                                                                                        
1.444     • https://repo.anaconda.com/pkgs/r
1.444 
1.444 To accept a channel's Terms of Service, run the following and replace CHANNEL with the channel name/URL:
1.444     ‣ conda tos accept --override-channels --channel CHANNEL


and


1.201 error: invalid-installed-package
1.201
1.201 × Cannot process installed package celery 5.1.2 in '/opt/conda/lib/python3.10/site-packages' because it has an invalid requirement:
1.201 │ Expected matching RIGHT_PARENTHESIS for LEFT_PARENTHESIS, after version specifier
1.201 │ pytz (>dev)
1.201 │ ~^
1.201 ╰─> Starting with pip 24.1, packages with invalid requirements can not be processed.
1.201
1.201 hint: To proceed this package must be uninstalled.
```