### PR TITLE
fix: increase padding between sidebar and main content

### DIFF
--- a/packages/lab/style/base.css
+++ b/packages/lab/style/base.css
@@ -291,20 +291,20 @@
   position: relative;
   background-color: white;
   padding-top: 0px;
-  padding-left: 5px;
+  padding-left: 14px;
   padding-right: 5px;
   padding-bottom: 5px;
 }
 
 .mercury-right-top-panel.mercury-right-top-panel-with-sidebar-toggle {
-  padding-left: 5px;
+  padding-left: 14px;
 }
 
 .mercury-right-bottom-panel {
   overflow: hidden !important;
   /* border-top: 1px solid var(--jp-border-color2); */
   padding-top: 5px;
-  padding-left: 5px;
+  padding-left: 14px;
   padding-right: 5px;
   padding-bottom: 5px;
 }
@@ -312,7 +312,7 @@
 .mercury-right-top-panel.mercury-right-limited,
 .mercury-right-bottom-panel.mercury-right-limited {
   box-sizing: border-box;
-  padding-left: 5px !important; 
+  padding-left: 14px !important; 
   padding-right: 5px !important;
 }
 


### PR DESCRIPTION
Closes #556

The `padding-left` on `.mercury-right-top-panel` and `.mercury-right-bottom-panel` was set to `5px`, which made the gap between the left sidebar and the main content area feel too cramped.

Increased `padding-left` from `5px` to `14px` across all affected selectors in `packages/lab/style/base.css`.

**File changed:** `packages/lab/style/base.css`

