### PR TITLE
docs: Altair dark theme plots tutorial

### DIFF
--- a/docs/notebooks/altair_dark_theme.ipynb
+++ b/docs/notebooks/altair_dark_theme.ipynb
@@ -1,0 +1,375 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "e0e82063",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import mercury as mr\n",
+    "import altair as alt\n",
+    "from vega_datasets import data\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "f064ff59",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\Users\\PC\\AppData\\Local\\Temp\\ipykernel_29052\\968473566.py:25: AltairDeprecationWarning: \n",
+      "Deprecated since `altair=5.5.0`. Use altair.theme instead.\n",
+      "Most cases require only the following change:\n",
+      "\n",
+      "    # Deprecated\n",
+      "    alt.themes.enable('quartz')\n",
+      "\n",
+      "    # Updated\n",
+      "    alt.theme.enable('quartz')\n",
+      "\n",
+      "If your code registers a theme, make the following change:\n",
+      "\n",
+      "    # Deprecated\n",
+      "    def custom_theme():\n",
+      "        return {'height': 400, 'width': 700}\n",
+      "    alt.themes.register('theme_name', custom_theme)\n",
+      "    alt.themes.enable('theme_name')\n",
+      "\n",
+      "    # Updated\n",
+      "    @alt.theme.register('theme_name', enable=True)\n",
+      "    def custom_theme():\n",
+      "        return alt.theme.ThemeConfig(\n",
+      "            {'height': 400, 'width': 700}\n",
+      "        )\n",
+      "\n",
+      "See the updated User Guide for further details:\n",
+      "    https://altair-viz.github.io/user_guide/api.html#theme\n",
+      "    https://altair-viz.github.io/user_guide/customization.html#chart-themes\n",
+      "  alt.themes.register(\"dark\", dark_theme)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "ThemeRegistry.enable('dark')"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Register dark theme for Altair\n",
+    "def dark_theme():\n",
+    "    return {\n",
+    "        \"config\": {\n",
+    "            \"background\": \"#1e1e2e\",\n",
+    "            \"view\": {\"stroke\": \"transparent\"},\n",
+    "            \"title\": {\"color\": \"#cdd6f4\", \"fontSize\": 16, \"font\": \"sans-serif\"},\n",
+    "            \"axis\": {\n",
+    "                \"domainColor\": \"#45475a\",\n",
+    "                \"gridColor\": \"#313244\",\n",
+    "                \"labelColor\": \"#bac2de\",\n",
+    "                \"tickColor\": \"#45475a\",\n",
+    "                \"titleColor\": \"#cdd6f4\",\n",
+    "            },\n",
+    "            \"legend\": {\n",
+    "                \"labelColor\": \"#bac2de\",\n",
+    "                \"titleColor\": \"#cdd6f4\",\n",
+    "            },\n",
+    "            \"range\": {\n",
+    "                \"category\": [\"#89b4fa\", \"#a6e3a1\", \"#fab387\", \"#f38ba8\", \"#cba6f7\", \"#94e2d5\"],\n",
+    "            },\n",
+    "        }\n",
+    "    }\n",
+    "\n",
+    "alt.themes.register(\"dark\", dark_theme)\n",
+    "alt.themes.enable(\"dark\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "9b3f9a68",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/mercury+json": {
+       "model_id": "45e0168690334979bb85d0c681d84605",
+       "position": "sidebar",
+       "widget": "SelectWidget"
+      },
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "45e0168690334979bb85d0c681d84605",
+       "version_major": 2,
+       "version_minor": 1
+      },
+      "text/plain": [
+       "<mercury.select.SelectWidget object at 0x00000222853AEBA0>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/mercury+json": {
+       "model_id": "baa10200da0948f28029974bb167a168",
+       "position": "sidebar",
+       "widget": "CheckboxWidget"
+      },
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "baa10200da0948f28029974bb167a168",
+       "version_major": 2,
+       "version_minor": 1
+      },
+      "text/plain": [
+       "<mercury.checkbox.CheckboxWidget object at 0x0000022291006E40>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Mercury widget: choose which chart to display\n",
+    "chart_select = mr.Select(\n",
+    "    value=\"Scatter: Horsepower vs MPG\",\n",
+    "    choices=[\"Scatter: Horsepower vs MPG\", \"Line: Stock Prices\", \"Bar: Seattle Precipitation\"],\n",
+    "    label=\"Choose Chart\",\n",
+    ")\n",
+    "\n",
+    "# Mercury widget: toggle dark theme on/off\n",
+    "use_dark = mr.CheckBox(value=True, label=\"Dark Theme\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "5b0faea8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Apply or remove theme based on checkbox\n",
+    "if use_dark.value:\n",
+    "    alt.themes.enable(\"dark\")\n",
+    "else:\n",
+    "    alt.themes.enable(\"default\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "7073f474",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Chart 1 — Scatter plot\n",
+    "cars = data.cars()\n",
+    "\n",
+    "scatter = (\n",
+    "    alt.Chart(cars)\n",
+    "    .mark_circle(size=70, opacity=0.85)\n",
+    "    .encode(\n",
+    "        x=alt.X(\"Horsepower:Q\", title=\"Horsepower\"),\n",
+    "        y=alt.Y(\"Miles_per_Gallon:Q\", title=\"Miles per Gallon\"),\n",
+    "        color=alt.Color(\"Origin:N\", legend=alt.Legend(title=\"Origin\")),\n",
+    "        tooltip=[\"Name\", \"Horsepower\", \"Miles_per_Gallon\", \"Origin\"],\n",
+    "    )\n",
+    "    .properties(title=\"Horsepower vs Miles per Gallon\", width=600, height=350)\n",
+    "    .interactive()\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "e8781852",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Chart 2 — Multi-line stock chart\n",
+    "stocks = data.stocks()\n",
+    "\n",
+    "line = (\n",
+    "    alt.Chart(stocks)\n",
+    "    .mark_line(strokeWidth=2)\n",
+    "    .encode(\n",
+    "        x=alt.X(\"date:T\", title=\"Date\"),\n",
+    "        y=alt.Y(\"price:Q\", title=\"Price (USD)\"),\n",
+    "        color=alt.Color(\"symbol:N\", legend=alt.Legend(title=\"Stock\")),\n",
+    "        tooltip=[\"symbol\", \"date\", \"price\"],\n",
+    "    )\n",
+    "    .properties(title=\"Stock Prices Over Time\", width=600, height=350)\n",
+    "    .interactive()\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "2efc1a11",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Chart 3 — Bar chart of monthly precipitation\n",
+    "seattle = data.seattle_weather()\n",
+    "seattle[\"month\"] = pd.to_datetime(seattle[\"date\"]).dt.strftime(\"%b\")\n",
+    "month_order = [\"Jan\", \"Feb\", \"Mar\", \"Apr\", \"May\", \"Jun\",\n",
+    "               \"Jul\", \"Aug\", \"Sep\", \"Oct\", \"Nov\", \"Dec\"]\n",
+    "monthly_precip = seattle.groupby(\"month\", as_index=False)[\"precipitation\"].mean()\n",
+    "\n",
+    "bar = (\n",
+    "    alt.Chart(monthly_precip)\n",
+    "    .mark_bar(cornerRadiusTopLeft=3, cornerRadiusTopRight=3)\n",
+    "    .encode(\n",
+    "        x=alt.X(\"month:N\", sort=month_order, title=\"Month\"),\n",
+    "        y=alt.Y(\"precipitation:Q\", title=\"Avg Precipitation (mm)\"),\n",
+    "        color=alt.Color(\n",
+    "            \"precipitation:Q\",\n",
+    "            scale=alt.Scale(scheme=\"blues\"),\n",
+    "            legend=None,\n",
+    "        ),\n",
+    "        tooltip=[\"month\", alt.Tooltip(\"precipitation:Q\", format=\".2f\")],\n",
+    "    )\n",
+    "    .properties(title=\"Seattle: Average Monthly Precipitation\", width=600, height=350)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "2635a46a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "<style>\n",
+       "  #altair-viz-4140237f4b054672a0a23482d599f0a8.vega-embed {\n",
+       "    width: 100%;\n",
+       "    display: flex;\n",
+       "  }\n",
+       "\n",
+       "  #altair-viz-4140237f4b054672a0a23482d599f0a8.vega-embed details,\n",
+       "  #altair-viz-4140237f4b054672a0a23482d599f0a8.vega-embed details summary {\n",
+       "    position: relative;\n",
+       "  }\n",
+       "</style>\n",
+       "<div id=\"altair-viz-4140237f4b054672a0a23482d599f0a8\"></div>\n",
+       "<script type=\"text/javascript\">\n",
+       "  var VEGA_DEBUG = (typeof VEGA_DEBUG == \"undefined\") ? {} : VEGA_DEBUG;\n",
+       "  (function(spec, embedOpt){\n",
+       "    let outputDiv = document.currentScript.previousElementSibling;\n",
+       "    if (outputDiv.id !== \"altair-viz-4140237f4b054672a0a23482d599f0a8\") {\n",
+       "      outputDiv = document.getElementById(\"altair-viz-4140237f4b054672a0a23482d599f0a8\");\n",
+       "    }\n",
+       "\n",
+       "    const paths = {\n",
+       "      \"vega\": \"https://cdn.jsdelivr.net/npm/vega@6?noext\",\n",
+       "      \"vega-lib\": \"https://cdn.jsdelivr.net/npm/vega-lib?noext\",\n",
+       "      \"vega-lite\": \"https://cdn.jsdelivr.net/npm/vega-lite@6.4.1?noext\",\n",
+       "      \"vega-embed\": \"https://cdn.jsdelivr.net/npm/vega-embed@7?noext\",\n",
+       "    };\n",
+       "\n",
+       "    function maybeLoadScript(lib, version) {\n",
+       "      var key = `${lib.replace(\"-\", \"\")}_version`;\n",
+       "      return (VEGA_DEBUG[key] == version) ?\n",
+       "        Promise.resolve(paths[lib]) :\n",
+       "        new Promise(function(resolve, reject) {\n",
+       "          var s = document.createElement('script');\n",
+       "          document.getElementsByTagName(\"head\")[0].appendChild(s);\n",
+       "          s.async = true;\n",
+       "          s.onload = () => {\n",
+       "            VEGA_DEBUG[key] = version;\n",
+       "            return resolve(paths[lib]);\n",
+       "          };\n",
+       "          s.onerror = () => reject(`Error loading script: ${paths[lib]}`);\n",
+       "          s.src = paths[lib];\n",
+       "        });\n",
+       "    }\n",
+       "\n",
+       "    function showError(err) {\n",
+       "      outputDiv.innerHTML = `<div class=\"error\" style=\"color:red;\">${err}</div>`;\n",
+       "      throw err;\n",
+       "    }\n",
+       "\n",
+       "    function displayChart(vegaEmbed) {\n",
+       "      vegaEmbed(outputDiv, spec, embedOpt)\n",
+       "        .catch(err => showError(`Javascript Error: ${err.message}<br>This usually means there's a typo in your chart specification. See the javascript console for the full traceback.`));\n",
+       "    }\n",
+       "\n",
+       "    if(typeof define === \"function\" && define.amd) {\n",
+       "      requirejs.config({paths});\n",
+       "      let deps = [\"vega-embed\"];\n",
+       "      require(deps, displayChart, err => showError(`Error loading script: ${err.message}`));\n",
+       "    } else {\n",
+       "      maybeLoadScript(\"vega\", \"6\")\n",
+       "        .then(() => maybeLoadScript(\"vega-lite\", \"6.4.1\"))\n",
+       "        .then(() => maybeLoadScript(\"vega-embed\", \"7\"))\n",
+       "        .catch(showError)\n",
+       "        .then(() => displayChart(vegaEmbed));\n",
+       "    }\n",
+       "  })({\"config\": {\"background\": \"#1e1e2e\", \"view\": {\"stroke\": \"transparent\"}, \"title\": {\"color\": \"#cdd6f4\", \"fontSize\": 16, \"font\": \"sans-serif\"}, \"axis\": {\"domainColor\": \"#45475a\", \"gridColor\": \"#313244\", \"labelColor\": \"#bac2de\", \"tickColor\": \"#45475a\", \"titleColor\": \"#cdd6f4\"}, \"legend\": {\"labelColor\": \"#bac2de\", \"titleColor\": \"#cdd6f4\"}, \"range\": {\"category\": [\"#89b4fa\", \"#a6e3a1\", \"#fab387\", \"#f38ba8\", \"#cba6f7\", \"#94e2d5\"]}}, \"data\": {\"name\": \"data-b0fe595546d47c5085f225c35730172c\"}, \"mark\": {\"type\": \"line\", \"strokeWidth\": 2}, \"encoding\": {\"color\": {\"field\": \"symbol\", \"legend\": {\"title\": \"Stock\"}, \"type\": \"nominal\"}, \"tooltip\": [{\"field\": \"symbol\", \"type\": \"nominal\"}, {\"field\": \"date\", \"type\": \"temporal\"}, {\"field\": \"price\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"date\", \"title\": \"Date\", \"type\": \"temporal\"}, \"y\": {\"field\": \"price\", \"title\": \"Price (USD)\", \"type\": \"quantitative\"}}, \"height\": 350, \"params\": [{\"name\": \"param_1e9efca18e7a2868\", \"select\": {\"type\": \"interval\", \"encodings\": [\"x\", \"y\"]}, \"bind\": \"scales\"}], \"title\": \"Stock Prices Over Time\", \"width\": 600, \"$schema\": \"https://vega.github.io/schema/vega-lite/v6.4.1.json\", \"datasets\": {\"data-b0fe595546d47c5085f225c35730172c\": [{\"symbol\": \"MSFT\", \"date\": \"2000-01-01T00:00:00\", \"price\": 39.81}, {\"symbol\": \"MSFT\", \"date\": \"2000-02-01T00:00:00\", \"price\": 36.35}, {\"symbol\": \"MSFT\", \"date\": \"2000-03-01T00:00:00\", \"price\": 43.22}, {\"symbol\": \"MSFT\", \"date\": \"2000-04-01T00:00:00\", \"price\": 28.37}, {\"symbol\": \"MSFT\", \"date\": \"2000-05-01T00:00:00\", \"price\": 25.45}, {\"symbol\": \"MSFT\", \"date\": \"2000-06-01T00:00:00\", \"price\": 32.54}, {\"symbol\": \"MSFT\", \"date\": \"2000-07-01T00:00:00\", \"price\": 28.4}, {\"symbol\": \"MSFT\", \"date\": \"2000-08-01T00:00:00\", \"price\": 28.4}, {\"symbol\": \"MSFT\", \"date\": \"2000-09-01T00:00:00\", \"price\": 24.53}, {\"symbol\": \"MSFT\", \"date\": \"2000-10-01T00:00:00\", \"price\": 28.02}, {\"symbol\": \"MSFT\", \"date\": \"2000-11-01T00:00:00\", \"price\": 23.34}, {\"symbol\": \"MSFT\", \"date\": \"2000-12-01T00:00:00\", \"price\": 17.65}, {\"symbol\": \"MSFT\", \"date\": \"2001-01-01T00:00:00\", \"price\": 24.84}, {\"symbol\": \"MSFT\", \"date\": \"2001-02-01T00:00:00\", \"price\": 24.0}, {\"symbol\": \"MSFT\", \"date\": \"2001-03-01T00:00:00\", \"price\": 22.25}, {\"symbol\": \"MSFT\", \"date\": \"2001-04-01T00:00:00\", \"price\": 27.56}, {\"symbol\": \"MSFT\", \"date\": \"2001-05-01T00:00:00\", \"price\": 28.14}, {\"symbol\": \"MSFT\", \"date\": \"2001-06-01T00:00:00\", \"price\": 29.7}, {\"symbol\": \"MSFT\", \"date\": \"2001-07-01T00:00:00\", \"price\": 26.93}, {\"symbol\": \"MSFT\", \"date\": \"2001-08-01T00:00:00\", \"price\": 23.21}, {\"symbol\": \"MSFT\", \"date\": \"2001-09-01T00:00:00\", \"price\": 20.82}, {\"symbol\": \"MSFT\", \"date\": \"2001-10-01T00:00:00\", \"price\": 23.65}, {\"symbol\": \"MSFT\", \"date\": \"2001-11-01T00:00:00\", \"price\": 26.12}, {\"symbol\": \"MSFT\", \"date\": \"2001-12-01T00:00:00\", \"price\": 26.95}, {\"symbol\": \"MSFT\", \"date\": \"2002-01-01T00:00:00\", \"price\": 25.92}, {\"symbol\": \"MSFT\", \"date\": \"2002-02-01T00:00:00\", \"price\": 23.73}, {\"symbol\": \"MSFT\", \"date\": \"2002-03-01T00:00:00\", \"price\": 24.53}, {\"symbol\": \"MSFT\", \"date\": \"2002-04-01T00:00:00\", \"price\": 21.26}, {\"symbol\": \"MSFT\", \"date\": \"2002-05-01T00:00:00\", \"price\": 20.71}, {\"symbol\": \"MSFT\", \"date\": \"2002-06-01T00:00:00\", \"price\": 22.25}, {\"symbol\": \"MSFT\", \"date\": \"2002-07-01T00:00:00\", \"price\": 19.52}, {\"symbol\": \"MSFT\", \"date\": \"2002-08-01T00:00:00\", \"price\": 19.97}, {\"symbol\": \"MSFT\", \"date\": \"2002-09-01T00:00:00\", \"price\": 17.79}, {\"symbol\": \"MSFT\", \"date\": \"2002-10-01T00:00:00\", \"price\": 21.75}, {\"symbol\": \"MSFT\", \"date\": \"2002-11-01T00:00:00\", \"price\": 23.46}, {\"symbol\": \"MSFT\", \"date\": \"2002-12-01T00:00:00\", \"price\": 21.03}, {\"symbol\": \"MSFT\", \"date\": \"2003-01-01T00:00:00\", \"price\": 19.31}, {\"symbol\": \"MSFT\", \"date\": \"2003-02-01T00:00:00\", \"price\": 19.34}, {\"symbol\": \"MSFT\", \"date\": \"2003-03-01T00:00:00\", \"price\": 19.76}, {\"symbol\": \"MSFT\", \"date\": \"2003-04-01T00:00:00\", \"price\": 20.87}, {\"symbol\": \"MSFT\", \"date\": \"2003-05-01T00:00:00\", \"price\": 20.09}, {\"symbol\": \"MSFT\", \"date\": \"2003-06-01T00:00:00\", \"price\": 20.93}, {\"symbol\": \"MSFT\", \"date\": \"2003-07-01T00:00:00\", \"price\": 21.56}, {\"symbol\": \"MSFT\", \"date\": \"2003-08-01T00:00:00\", \"price\": 21.65}, {\"symbol\": \"MSFT\", \"date\": \"2003-09-01T00:00:00\", \"price\": 22.69}, {\"symbol\": \"MSFT\", \"date\": \"2003-10-01T00:00:00\", \"price\": 21.45}, {\"symbol\": \"MSFT\", \"date\": \"2003-11-01T00:00:00\", \"price\": 21.1}, {\"symbol\": \"MSFT\", \"date\": \"2003-12-01T00:00:00\", \"price\": 22.46}, {\"symbol\": \"MSFT\", \"date\": \"2004-01-01T00:00:00\", \"price\": 22.69}, {\"symbol\": \"MSFT\", \"date\": \"2004-02-01T00:00:00\", \"price\": 21.77}, {\"symbol\": \"MSFT\", \"date\": \"2004-03-01T00:00:00\", \"price\": 20.46}, {\"symbol\": \"MSFT\", \"date\": \"2004-04-01T00:00:00\", \"price\": 21.45}, {\"symbol\": \"MSFT\", \"date\": \"2004-05-01T00:00:00\", \"price\": 21.53}, {\"symbol\": \"MSFT\", \"date\": \"2004-06-01T00:00:00\", \"price\": 23.44}, {\"symbol\": \"MSFT\", \"date\": \"2004-07-01T00:00:00\", \"price\": 23.38}, {\"symbol\": \"MSFT\", \"date\": \"2004-08-01T00:00:00\", \"price\": 22.47}, {\"symbol\": \"MSFT\", \"date\": \"2004-09-01T00:00:00\", \"price\": 22.76}, {\"symbol\": \"MSFT\", \"date\": \"2004-10-01T00:00:00\", \"price\": 23.02}, {\"symbol\": \"MSFT\", \"date\": \"2004-11-01T00:00:00\", \"price\": 24.6}, {\"symbol\": \"MSFT\", \"date\": \"2004-12-01T00:00:00\", \"price\": 24.52}, {\"symbol\": \"MSFT\", \"date\": \"2005-01-01T00:00:00\", \"price\": 24.11}, {\"symbol\": \"MSFT\", \"date\": \"2005-02-01T00:00:00\", \"price\": 23.15}, {\"symbol\": \"MSFT\", \"date\": \"2005-03-01T00:00:00\", \"price\": 22.24}, {\"symbol\": \"MSFT\", \"date\": \"2005-04-01T00:00:00\", \"price\": 23.28}, {\"symbol\": \"MSFT\", \"date\": \"2005-05-01T00:00:00\", \"price\": 23.82}, {\"symbol\": \"MSFT\", \"date\": \"2005-06-01T00:00:00\", \"price\": 22.93}, {\"symbol\": \"MSFT\", \"date\": \"2005-07-01T00:00:00\", \"price\": 23.64}, {\"symbol\": \"MSFT\", \"date\": \"2005-08-01T00:00:00\", \"price\": 25.35}, {\"symbol\": \"MSFT\", \"date\": \"2005-09-01T00:00:00\", \"price\": 23.83}, {\"symbol\": \"MSFT\", \"date\": \"2005-10-01T00:00:00\", \"price\": 23.8}, {\"symbol\": \"MSFT\", \"date\": \"2005-11-01T00:00:00\", \"price\": 25.71}, {\"symbol\": \"MSFT\", \"date\": \"2005-12-01T00:00:00\", \"price\": 24.29}, {\"symbol\": \"MSFT\", \"date\": \"2006-01-01T00:00:00\", \"price\": 26.14}, {\"symbol\": \"MSFT\", \"date\": \"2006-02-01T00:00:00\", \"price\": 25.04}, {\"symbol\": \"MSFT\", \"date\": \"2006-03-01T00:00:00\", \"price\": 25.36}, {\"symbol\": \"MSFT\", \"date\": \"2006-04-01T00:00:00\", \"price\": 22.5}, {\"symbol\": \"MSFT\", \"date\": \"2006-05-01T00:00:00\", \"price\": 21.19}, {\"symbol\": \"MSFT\", \"date\": \"2006-06-01T00:00:00\", \"price\": 21.8}, {\"symbol\": \"MSFT\", \"date\": \"2006-07-01T00:00:00\", \"price\": 22.51}, {\"symbol\": \"MSFT\", \"date\": \"2006-08-01T00:00:00\", \"price\": 24.13}, {\"symbol\": \"MSFT\", \"date\": \"2006-09-01T00:00:00\", \"price\": 25.68}, {\"symbol\": \"MSFT\", \"date\": \"2006-10-01T00:00:00\", \"price\": 26.96}, {\"symbol\": \"MSFT\", \"date\": \"2006-11-01T00:00:00\", \"price\": 27.66}, {\"symbol\": \"MSFT\", \"date\": \"2006-12-01T00:00:00\", \"price\": 28.13}, {\"symbol\": \"MSFT\", \"date\": \"2007-01-01T00:00:00\", \"price\": 29.07}, {\"symbol\": \"MSFT\", \"date\": \"2007-02-01T00:00:00\", \"price\": 26.63}, {\"symbol\": \"MSFT\", \"date\": \"2007-03-01T00:00:00\", \"price\": 26.35}, {\"symbol\": \"MSFT\", \"date\": \"2007-04-01T00:00:00\", \"price\": 28.3}, {\"symbol\": \"MSFT\", \"date\": \"2007-05-01T00:00:00\", \"price\": 29.11}, {\"symbol\": \"MSFT\", \"date\": \"2007-06-01T00:00:00\", \"price\": 27.95}, {\"symbol\": \"MSFT\", \"date\": \"2007-07-01T00:00:00\", \"price\": 27.5}, {\"symbol\": \"MSFT\", \"date\": \"2007-08-01T00:00:00\", \"price\": 27.34}, {\"symbol\": \"MSFT\", \"date\": \"2007-09-01T00:00:00\", \"price\": 28.04}, {\"symbol\": \"MSFT\", \"date\": \"2007-10-01T00:00:00\", \"price\": 35.03}, {\"symbol\": \"MSFT\", \"date\": \"2007-11-01T00:00:00\", \"price\": 32.09}, {\"symbol\": \"MSFT\", \"date\": \"2007-12-01T00:00:00\", \"price\": 34.0}, {\"symbol\": \"MSFT\", \"date\": \"2008-01-01T00:00:00\", \"price\": 31.13}, {\"symbol\": \"MSFT\", \"date\": \"2008-02-01T00:00:00\", \"price\": 26.07}, {\"symbol\": \"MSFT\", \"date\": \"2008-03-01T00:00:00\", \"price\": 27.21}, {\"symbol\": \"MSFT\", \"date\": \"2008-04-01T00:00:00\", \"price\": 27.34}, {\"symbol\": \"MSFT\", \"date\": \"2008-05-01T00:00:00\", \"price\": 27.25}, {\"symbol\": \"MSFT\", \"date\": \"2008-06-01T00:00:00\", \"price\": 26.47}, {\"symbol\": \"MSFT\", \"date\": \"2008-07-01T00:00:00\", \"price\": 24.75}, {\"symbol\": \"MSFT\", \"date\": \"2008-08-01T00:00:00\", \"price\": 26.36}, {\"symbol\": \"MSFT\", \"date\": \"2008-09-01T00:00:00\", \"price\": 25.78}, {\"symbol\": \"MSFT\", \"date\": \"2008-10-01T00:00:00\", \"price\": 21.57}, {\"symbol\": \"MSFT\", \"date\": \"2008-11-01T00:00:00\", \"price\": 19.66}, {\"symbol\": \"MSFT\", \"date\": \"2008-12-01T00:00:00\", \"price\": 18.91}, {\"symbol\": \"MSFT\", \"date\": \"2009-01-01T00:00:00\", \"price\": 16.63}, {\"symbol\": \"MSFT\", \"date\": \"2009-02-01T00:00:00\", \"price\": 15.81}, {\"symbol\": \"MSFT\", \"date\": \"2009-03-01T00:00:00\", \"price\": 17.99}, {\"symbol\": \"MSFT\", \"date\": \"2009-04-01T00:00:00\", \"price\": 19.84}, {\"symbol\": \"MSFT\", \"date\": \"2009-05-01T00:00:00\", \"price\": 20.59}, {\"symbol\": \"MSFT\", \"date\": \"2009-06-01T00:00:00\", \"price\": 23.42}, {\"symbol\": \"MSFT\", \"date\": \"2009-07-01T00:00:00\", \"price\": 23.18}, {\"symbol\": \"MSFT\", \"date\": \"2009-08-01T00:00:00\", \"price\": 24.43}, {\"symbol\": \"MSFT\", \"date\": \"2009-09-01T00:00:00\", \"price\": 25.49}, {\"symbol\": \"MSFT\", \"date\": \"2009-10-01T00:00:00\", \"price\": 27.48}, {\"symbol\": \"MSFT\", \"date\": \"2009-11-01T00:00:00\", \"price\": 29.27}, {\"symbol\": \"MSFT\", \"date\": \"2009-12-01T00:00:00\", \"price\": 30.34}, {\"symbol\": \"MSFT\", \"date\": \"2010-01-01T00:00:00\", \"price\": 28.05}, {\"symbol\": \"MSFT\", \"date\": \"2010-02-01T00:00:00\", \"price\": 28.67}, {\"symbol\": \"MSFT\", \"date\": \"2010-03-01T00:00:00\", \"price\": 28.8}, {\"symbol\": \"AMZN\", \"date\": \"2000-01-01T00:00:00\", \"price\": 64.56}, {\"symbol\": \"AMZN\", \"date\": \"2000-02-01T00:00:00\", \"price\": 68.87}, {\"symbol\": \"AMZN\", \"date\": \"2000-03-01T00:00:00\", \"price\": 67.0}, {\"symbol\": \"AMZN\", \"date\": \"2000-04-01T00:00:00\", \"price\": 55.19}, {\"symbol\": \"AMZN\", \"date\": \"2000-05-01T00:00:00\", \"price\": 48.31}, {\"symbol\": \"AMZN\", \"date\": \"2000-06-01T00:00:00\", \"price\": 36.31}, {\"symbol\": \"AMZN\", \"date\": \"2000-07-01T00:00:00\", \"price\": 30.12}, {\"symbol\": \"AMZN\", \"date\": \"2000-08-01T00:00:00\", \"price\": 41.5}, {\"symbol\": \"AMZN\", \"date\": \"2000-09-01T00:00:00\", \"price\": 38.44}, {\"symbol\": \"AMZN\", \"date\": \"2000-10-01T00:00:00\", \"price\": 36.62}, {\"symbol\": \"AMZN\", \"date\": \"2000-11-01T00:00:00\", \"price\": 24.69}, {\"symbol\": \"AMZN\", \"date\": \"2000-12-01T00:00:00\", \"price\": 15.56}, {\"symbol\": \"AMZN\", \"date\": \"2001-01-01T00:00:00\", \"price\": 17.31}, {\"symbol\": \"AMZN\", \"date\": \"2001-02-01T00:00:00\", \"price\": 10.19}, {\"symbol\": \"AMZN\", \"date\": \"2001-03-01T00:00:00\", \"price\": 10.23}, {\"symbol\": \"AMZN\", \"date\": \"2001-04-01T00:00:00\", \"price\": 15.78}, {\"symbol\": \"AMZN\", \"date\": \"2001-05-01T00:00:00\", \"price\": 16.69}, {\"symbol\": \"AMZN\", \"date\": \"2001-06-01T00:00:00\", \"price\": 14.15}, {\"symbol\": \"AMZN\", \"date\": \"2001-07-01T00:00:00\", \"price\": 12.49}, {\"symbol\": \"AMZN\", \"date\": \"2001-08-01T00:00:00\", \"price\": 8.94}, {\"symbol\": \"AMZN\", \"date\": \"2001-09-01T00:00:00\", \"price\": 5.97}, {\"symbol\": \"AMZN\", \"date\": \"2001-10-01T00:00:00\", \"price\": 6.98}, {\"symbol\": \"AMZN\", \"date\": \"2001-11-01T00:00:00\", \"price\": 11.32}, {\"symbol\": \"AMZN\", \"date\": \"2001-12-01T00:00:00\", \"price\": 10.82}, {\"symbol\": \"AMZN\", \"date\": \"2002-01-01T00:00:00\", \"price\": 14.19}, {\"symbol\": \"AMZN\", \"date\": \"2002-02-01T00:00:00\", \"price\": 14.1}, {\"symbol\": \"AMZN\", \"date\": \"2002-03-01T00:00:00\", \"price\": 14.3}, {\"symbol\": \"AMZN\", \"date\": \"2002-04-01T00:00:00\", \"price\": 16.69}, {\"symbol\": \"AMZN\", \"date\": \"2002-05-01T00:00:00\", \"price\": 18.23}, {\"symbol\": \"AMZN\", \"date\": \"2002-06-01T00:00:00\", \"price\": 16.25}, {\"symbol\": \"AMZN\", \"date\": \"2002-07-01T00:00:00\", \"price\": 14.45}, {\"symbol\": \"AMZN\", \"date\": \"2002-08-01T00:00:00\", \"price\": 14.94}, {\"symbol\": \"AMZN\", \"date\": \"2002-09-01T00:00:00\", \"price\": 15.93}, {\"symbol\": \"AMZN\", \"date\": \"2002-10-01T00:00:00\", \"price\": 19.36}, {\"symbol\": \"AMZN\", \"date\": \"2002-11-01T00:00:00\", \"price\": 23.35}, {\"symbol\": \"AMZN\", \"date\": \"2002-12-01T00:00:00\", \"price\": 18.89}, {\"symbol\": \"AMZN\", \"date\": \"2003-01-01T00:00:00\", \"price\": 21.85}, {\"symbol\": \"AMZN\", \"date\": \"2003-02-01T00:00:00\", \"price\": 22.01}, {\"symbol\": \"AMZN\", \"date\": \"2003-03-01T00:00:00\", \"price\": 26.03}, {\"symbol\": \"AMZN\", \"date\": \"2003-04-01T00:00:00\", \"price\": 28.69}, {\"symbol\": \"AMZN\", \"date\": \"2003-05-01T00:00:00\", \"price\": 35.89}, {\"symbol\": \"AMZN\", \"date\": \"2003-06-01T00:00:00\", \"price\": 36.32}, {\"symbol\": \"AMZN\", \"date\": \"2003-07-01T00:00:00\", \"price\": 41.64}, {\"symbol\": \"AMZN\", \"date\": \"2003-08-01T00:00:00\", \"price\": 46.32}, {\"symbol\": \"AMZN\", \"date\": \"2003-09-01T00:00:00\", \"price\": 48.43}, {\"symbol\": \"AMZN\", \"date\": \"2003-10-01T00:00:00\", \"price\": 54.43}, {\"symbol\": \"AMZN\", \"date\": \"2003-11-01T00:00:00\", \"price\": 53.97}, {\"symbol\": \"AMZN\", \"date\": \"2003-12-01T00:00:00\", \"price\": 52.62}, {\"symbol\": \"AMZN\", \"date\": \"2004-01-01T00:00:00\", \"price\": 50.4}, {\"symbol\": \"AMZN\", \"date\": \"2004-02-01T00:00:00\", \"price\": 43.01}, {\"symbol\": \"AMZN\", \"date\": \"2004-03-01T00:00:00\", \"price\": 43.28}, {\"symbol\": \"AMZN\", \"date\": \"2004-04-01T00:00:00\", \"price\": 43.6}, {\"symbol\": \"AMZN\", \"date\": \"2004-05-01T00:00:00\", \"price\": 48.5}, {\"symbol\": \"AMZN\", \"date\": \"2004-06-01T00:00:00\", \"price\": 54.4}, {\"symbol\": \"AMZN\", \"date\": \"2004-07-01T00:00:00\", \"price\": 38.92}, {\"symbol\": \"AMZN\", \"date\": \"2004-08-01T00:00:00\", \"price\": 38.14}, {\"symbol\": \"AMZN\", \"date\": \"2004-09-01T00:00:00\", \"price\": 40.86}, {\"symbol\": \"AMZN\", \"date\": \"2004-10-01T00:00:00\", \"price\": 34.13}, {\"symbol\": \"AMZN\", \"date\": \"2004-11-01T00:00:00\", \"price\": 39.68}, {\"symbol\": \"AMZN\", \"date\": \"2004-12-01T00:00:00\", \"price\": 44.29}, {\"symbol\": \"AMZN\", \"date\": \"2005-01-01T00:00:00\", \"price\": 43.22}, {\"symbol\": \"AMZN\", \"date\": \"2005-02-01T00:00:00\", \"price\": 35.18}, {\"symbol\": \"AMZN\", \"date\": \"2005-03-01T00:00:00\", \"price\": 34.27}, {\"symbol\": \"AMZN\", \"date\": \"2005-04-01T00:00:00\", \"price\": 32.36}, {\"symbol\": \"AMZN\", \"date\": \"2005-05-01T00:00:00\", \"price\": 35.51}, {\"symbol\": \"AMZN\", \"date\": \"2005-06-01T00:00:00\", \"price\": 33.09}, {\"symbol\": \"AMZN\", \"date\": \"2005-07-01T00:00:00\", \"price\": 45.15}, {\"symbol\": \"AMZN\", \"date\": \"2005-08-01T00:00:00\", \"price\": 42.7}, {\"symbol\": \"AMZN\", \"date\": \"2005-09-01T00:00:00\", \"price\": 45.3}, {\"symbol\": \"AMZN\", \"date\": \"2005-10-01T00:00:00\", \"price\": 39.86}, {\"symbol\": \"AMZN\", \"date\": \"2005-11-01T00:00:00\", \"price\": 48.46}, {\"symbol\": \"AMZN\", \"date\": \"2005-12-01T00:00:00\", \"price\": 47.15}, {\"symbol\": \"AMZN\", \"date\": \"2006-01-01T00:00:00\", \"price\": 44.82}, {\"symbol\": \"AMZN\", \"date\": \"2006-02-01T00:00:00\", \"price\": 37.44}, {\"symbol\": \"AMZN\", \"date\": \"2006-03-01T00:00:00\", \"price\": 36.53}, {\"symbol\": \"AMZN\", \"date\": \"2006-04-01T00:00:00\", \"price\": 35.21}, {\"symbol\": \"AMZN\", \"date\": \"2006-05-01T00:00:00\", \"price\": 34.61}, {\"symbol\": \"AMZN\", \"date\": \"2006-06-01T00:00:00\", \"price\": 38.68}, {\"symbol\": \"AMZN\", \"date\": \"2006-07-01T00:00:00\", \"price\": 26.89}, {\"symbol\": \"AMZN\", \"date\": \"2006-08-01T00:00:00\", \"price\": 30.83}, {\"symbol\": \"AMZN\", \"date\": \"2006-09-01T00:00:00\", \"price\": 32.12}, {\"symbol\": \"AMZN\", \"date\": \"2006-10-01T00:00:00\", \"price\": 38.09}, {\"symbol\": \"AMZN\", \"date\": \"2006-11-01T00:00:00\", \"price\": 40.34}, {\"symbol\": \"AMZN\", \"date\": \"2006-12-01T00:00:00\", \"price\": 39.46}, {\"symbol\": \"AMZN\", \"date\": \"2007-01-01T00:00:00\", \"price\": 37.67}, {\"symbol\": \"AMZN\", \"date\": \"2007-02-01T00:00:00\", \"price\": 39.14}, {\"symbol\": \"AMZN\", \"date\": \"2007-03-01T00:00:00\", \"price\": 39.79}, {\"symbol\": \"AMZN\", \"date\": \"2007-04-01T00:00:00\", \"price\": 61.33}, {\"symbol\": \"AMZN\", \"date\": \"2007-05-01T00:00:00\", \"price\": 69.14}, {\"symbol\": \"AMZN\", \"date\": \"2007-06-01T00:00:00\", \"price\": 68.41}, {\"symbol\": \"AMZN\", \"date\": \"2007-07-01T00:00:00\", \"price\": 78.54}, {\"symbol\": \"AMZN\", \"date\": \"2007-08-01T00:00:00\", \"price\": 79.91}, {\"symbol\": \"AMZN\", \"date\": \"2007-09-01T00:00:00\", \"price\": 93.15}, {\"symbol\": \"AMZN\", \"date\": \"2007-10-01T00:00:00\", \"price\": 89.15}, {\"symbol\": \"AMZN\", \"date\": \"2007-11-01T00:00:00\", \"price\": 90.56}, {\"symbol\": \"AMZN\", \"date\": \"2007-12-01T00:00:00\", \"price\": 92.64}, {\"symbol\": \"AMZN\", \"date\": \"2008-01-01T00:00:00\", \"price\": 77.7}, {\"symbol\": \"AMZN\", \"date\": \"2008-02-01T00:00:00\", \"price\": 64.47}, {\"symbol\": \"AMZN\", \"date\": \"2008-03-01T00:00:00\", \"price\": 71.3}, {\"symbol\": \"AMZN\", \"date\": \"2008-04-01T00:00:00\", \"price\": 78.63}, {\"symbol\": \"AMZN\", \"date\": \"2008-05-01T00:00:00\", \"price\": 81.62}, {\"symbol\": \"AMZN\", \"date\": \"2008-06-01T00:00:00\", \"price\": 73.33}, {\"symbol\": \"AMZN\", \"date\": \"2008-07-01T00:00:00\", \"price\": 76.34}, {\"symbol\": \"AMZN\", \"date\": \"2008-08-01T00:00:00\", \"price\": 80.81}, {\"symbol\": \"AMZN\", \"date\": \"2008-09-01T00:00:00\", \"price\": 72.76}, {\"symbol\": \"AMZN\", \"date\": \"2008-10-01T00:00:00\", \"price\": 57.24}, {\"symbol\": \"AMZN\", \"date\": \"2008-11-01T00:00:00\", \"price\": 42.7}, {\"symbol\": \"AMZN\", \"date\": \"2008-12-01T00:00:00\", \"price\": 51.28}, {\"symbol\": \"AMZN\", \"date\": \"2009-01-01T00:00:00\", \"price\": 58.82}, {\"symbol\": \"AMZN\", \"date\": \"2009-02-01T00:00:00\", \"price\": 64.79}, {\"symbol\": \"AMZN\", \"date\": \"2009-03-01T00:00:00\", \"price\": 73.44}, {\"symbol\": \"AMZN\", \"date\": \"2009-04-01T00:00:00\", \"price\": 80.52}, {\"symbol\": \"AMZN\", \"date\": \"2009-05-01T00:00:00\", \"price\": 77.99}, {\"symbol\": \"AMZN\", \"date\": \"2009-06-01T00:00:00\", \"price\": 83.66}, {\"symbol\": \"AMZN\", \"date\": \"2009-07-01T00:00:00\", \"price\": 85.76}, {\"symbol\": \"AMZN\", \"date\": \"2009-08-01T00:00:00\", \"price\": 81.19}, {\"symbol\": \"AMZN\", \"date\": \"2009-09-01T00:00:00\", \"price\": 93.36}, {\"symbol\": \"AMZN\", \"date\": \"2009-10-01T00:00:00\", \"price\": 118.81}, {\"symbol\": \"AMZN\", \"date\": \"2009-11-01T00:00:00\", \"price\": 135.91}, {\"symbol\": \"AMZN\", \"date\": \"2009-12-01T00:00:00\", \"price\": 134.52}, {\"symbol\": \"AMZN\", \"date\": \"2010-01-01T00:00:00\", \"price\": 125.41}, {\"symbol\": \"AMZN\", \"date\": \"2010-02-01T00:00:00\", \"price\": 118.4}, {\"symbol\": \"AMZN\", \"date\": \"2010-03-01T00:00:00\", \"price\": 128.82}, {\"symbol\": \"IBM\", \"date\": \"2000-01-01T00:00:00\", \"price\": 100.52}, {\"symbol\": \"IBM\", \"date\": \"2000-02-01T00:00:00\", \"price\": 92.11}, {\"symbol\": \"IBM\", \"date\": \"2000-03-01T00:00:00\", \"price\": 106.11}, {\"symbol\": \"IBM\", \"date\": \"2000-04-01T00:00:00\", \"price\": 99.95}, {\"symbol\": \"IBM\", \"date\": \"2000-05-01T00:00:00\", \"price\": 96.31}, {\"symbol\": \"IBM\", \"date\": \"2000-06-01T00:00:00\", \"price\": 98.33}, {\"symbol\": \"IBM\", \"date\": \"2000-07-01T00:00:00\", \"price\": 100.74}, {\"symbol\": \"IBM\", \"date\": \"2000-08-01T00:00:00\", \"price\": 118.62}, {\"symbol\": \"IBM\", \"date\": \"2000-09-01T00:00:00\", \"price\": 101.19}, {\"symbol\": \"IBM\", \"date\": \"2000-10-01T00:00:00\", \"price\": 88.5}, {\"symbol\": \"IBM\", \"date\": \"2000-11-01T00:00:00\", \"price\": 84.12}, {\"symbol\": \"IBM\", \"date\": \"2000-12-01T00:00:00\", \"price\": 76.47}, {\"symbol\": \"IBM\", \"date\": \"2001-01-01T00:00:00\", \"price\": 100.76}, {\"symbol\": \"IBM\", \"date\": \"2001-02-01T00:00:00\", \"price\": 89.98}, {\"symbol\": \"IBM\", \"date\": \"2001-03-01T00:00:00\", \"price\": 86.63}, {\"symbol\": \"IBM\", \"date\": \"2001-04-01T00:00:00\", \"price\": 103.7}, {\"symbol\": \"IBM\", \"date\": \"2001-05-01T00:00:00\", \"price\": 100.82}, {\"symbol\": \"IBM\", \"date\": \"2001-06-01T00:00:00\", \"price\": 102.35}, {\"symbol\": \"IBM\", \"date\": \"2001-07-01T00:00:00\", \"price\": 94.87}, {\"symbol\": \"IBM\", \"date\": \"2001-08-01T00:00:00\", \"price\": 90.25}, {\"symbol\": \"IBM\", \"date\": \"2001-09-01T00:00:00\", \"price\": 82.82}, {\"symbol\": \"IBM\", \"date\": \"2001-10-01T00:00:00\", \"price\": 97.58}, {\"symbol\": \"IBM\", \"date\": \"2001-11-01T00:00:00\", \"price\": 104.5}, {\"symbol\": \"IBM\", \"date\": \"2001-12-01T00:00:00\", \"price\": 109.36}, {\"symbol\": \"IBM\", \"date\": \"2002-01-01T00:00:00\", \"price\": 97.54}, {\"symbol\": \"IBM\", \"date\": \"2002-02-01T00:00:00\", \"price\": 88.82}, {\"symbol\": \"IBM\", \"date\": \"2002-03-01T00:00:00\", \"price\": 94.15}, {\"symbol\": \"IBM\", \"date\": \"2002-04-01T00:00:00\", \"price\": 75.82}, {\"symbol\": \"IBM\", \"date\": \"2002-05-01T00:00:00\", \"price\": 72.97}, {\"symbol\": \"IBM\", \"date\": \"2002-06-01T00:00:00\", \"price\": 65.31}, {\"symbol\": \"IBM\", \"date\": \"2002-07-01T00:00:00\", \"price\": 63.86}, {\"symbol\": \"IBM\", \"date\": \"2002-08-01T00:00:00\", \"price\": 68.52}, {\"symbol\": \"IBM\", \"date\": \"2002-09-01T00:00:00\", \"price\": 53.01}, {\"symbol\": \"IBM\", \"date\": \"2002-10-01T00:00:00\", \"price\": 71.76}, {\"symbol\": \"IBM\", \"date\": \"2002-11-01T00:00:00\", \"price\": 79.16}, {\"symbol\": \"IBM\", \"date\": \"2002-12-01T00:00:00\", \"price\": 70.58}, {\"symbol\": \"IBM\", \"date\": \"2003-01-01T00:00:00\", \"price\": 71.22}, {\"symbol\": \"IBM\", \"date\": \"2003-02-01T00:00:00\", \"price\": 71.13}, {\"symbol\": \"IBM\", \"date\": \"2003-03-01T00:00:00\", \"price\": 71.57}, {\"symbol\": \"IBM\", \"date\": \"2003-04-01T00:00:00\", \"price\": 77.47}, {\"symbol\": \"IBM\", \"date\": \"2003-05-01T00:00:00\", \"price\": 80.48}, {\"symbol\": \"IBM\", \"date\": \"2003-06-01T00:00:00\", \"price\": 75.42}, {\"symbol\": \"IBM\", \"date\": \"2003-07-01T00:00:00\", \"price\": 74.28}, {\"symbol\": \"IBM\", \"date\": \"2003-08-01T00:00:00\", \"price\": 75.12}, {\"symbol\": \"IBM\", \"date\": \"2003-09-01T00:00:00\", \"price\": 80.91}, {\"symbol\": \"IBM\", \"date\": \"2003-10-01T00:00:00\", \"price\": 81.96}, {\"symbol\": \"IBM\", \"date\": \"2003-11-01T00:00:00\", \"price\": 83.08}, {\"symbol\": \"IBM\", \"date\": \"2003-12-01T00:00:00\", \"price\": 85.05}, {\"symbol\": \"IBM\", \"date\": \"2004-01-01T00:00:00\", \"price\": 91.06}, {\"symbol\": \"IBM\", \"date\": \"2004-02-01T00:00:00\", \"price\": 88.7}, {\"symbol\": \"IBM\", \"date\": \"2004-03-01T00:00:00\", \"price\": 84.41}, {\"symbol\": \"IBM\", \"date\": \"2004-04-01T00:00:00\", \"price\": 81.04}, {\"symbol\": \"IBM\", \"date\": \"2004-05-01T00:00:00\", \"price\": 81.59}, {\"symbol\": \"IBM\", \"date\": \"2004-06-01T00:00:00\", \"price\": 81.19}, {\"symbol\": \"IBM\", \"date\": \"2004-07-01T00:00:00\", \"price\": 80.19}, {\"symbol\": \"IBM\", \"date\": \"2004-08-01T00:00:00\", \"price\": 78.17}, {\"symbol\": \"IBM\", \"date\": \"2004-09-01T00:00:00\", \"price\": 79.13}, {\"symbol\": \"IBM\", \"date\": \"2004-10-01T00:00:00\", \"price\": 82.84}, {\"symbol\": \"IBM\", \"date\": \"2004-11-01T00:00:00\", \"price\": 87.15}, {\"symbol\": \"IBM\", \"date\": \"2004-12-01T00:00:00\", \"price\": 91.16}, {\"symbol\": \"IBM\", \"date\": \"2005-01-01T00:00:00\", \"price\": 86.39}, {\"symbol\": \"IBM\", \"date\": \"2005-02-01T00:00:00\", \"price\": 85.78}, {\"symbol\": \"IBM\", \"date\": \"2005-03-01T00:00:00\", \"price\": 84.66}, {\"symbol\": \"IBM\", \"date\": \"2005-04-01T00:00:00\", \"price\": 70.77}, {\"symbol\": \"IBM\", \"date\": \"2005-05-01T00:00:00\", \"price\": 70.18}, {\"symbol\": \"IBM\", \"date\": \"2005-06-01T00:00:00\", \"price\": 68.93}, {\"symbol\": \"IBM\", \"date\": \"2005-07-01T00:00:00\", \"price\": 77.53}, {\"symbol\": \"IBM\", \"date\": \"2005-08-01T00:00:00\", \"price\": 75.07}, {\"symbol\": \"IBM\", \"date\": \"2005-09-01T00:00:00\", \"price\": 74.7}, {\"symbol\": \"IBM\", \"date\": \"2005-10-01T00:00:00\", \"price\": 76.25}, {\"symbol\": \"IBM\", \"date\": \"2005-11-01T00:00:00\", \"price\": 82.98}, {\"symbol\": \"IBM\", \"date\": \"2005-12-01T00:00:00\", \"price\": 76.73}, {\"symbol\": \"IBM\", \"date\": \"2006-01-01T00:00:00\", \"price\": 75.89}, {\"symbol\": \"IBM\", \"date\": \"2006-02-01T00:00:00\", \"price\": 75.09}, {\"symbol\": \"IBM\", \"date\": \"2006-03-01T00:00:00\", \"price\": 77.17}, {\"symbol\": \"IBM\", \"date\": \"2006-04-01T00:00:00\", \"price\": 77.05}, {\"symbol\": \"IBM\", \"date\": \"2006-05-01T00:00:00\", \"price\": 75.04}, {\"symbol\": \"IBM\", \"date\": \"2006-06-01T00:00:00\", \"price\": 72.15}, {\"symbol\": \"IBM\", \"date\": \"2006-07-01T00:00:00\", \"price\": 72.7}, {\"symbol\": \"IBM\", \"date\": \"2006-08-01T00:00:00\", \"price\": 76.35}, {\"symbol\": \"IBM\", \"date\": \"2006-09-01T00:00:00\", \"price\": 77.26}, {\"symbol\": \"IBM\", \"date\": \"2006-10-01T00:00:00\", \"price\": 87.06}, {\"symbol\": \"IBM\", \"date\": \"2006-11-01T00:00:00\", \"price\": 86.95}, {\"symbol\": \"IBM\", \"date\": \"2006-12-01T00:00:00\", \"price\": 91.9}, {\"symbol\": \"IBM\", \"date\": \"2007-01-01T00:00:00\", \"price\": 93.79}, {\"symbol\": \"IBM\", \"date\": \"2007-02-01T00:00:00\", \"price\": 88.18}, {\"symbol\": \"IBM\", \"date\": \"2007-03-01T00:00:00\", \"price\": 89.44}, {\"symbol\": \"IBM\", \"date\": \"2007-04-01T00:00:00\", \"price\": 96.98}, {\"symbol\": \"IBM\", \"date\": \"2007-05-01T00:00:00\", \"price\": 101.54}, {\"symbol\": \"IBM\", \"date\": \"2007-06-01T00:00:00\", \"price\": 100.25}, {\"symbol\": \"IBM\", \"date\": \"2007-07-01T00:00:00\", \"price\": 105.4}, {\"symbol\": \"IBM\", \"date\": \"2007-08-01T00:00:00\", \"price\": 111.54}, {\"symbol\": \"IBM\", \"date\": \"2007-09-01T00:00:00\", \"price\": 112.6}, {\"symbol\": \"IBM\", \"date\": \"2007-10-01T00:00:00\", \"price\": 111.0}, {\"symbol\": \"IBM\", \"date\": \"2007-11-01T00:00:00\", \"price\": 100.9}, {\"symbol\": \"IBM\", \"date\": \"2007-12-01T00:00:00\", \"price\": 103.7}, {\"symbol\": \"IBM\", \"date\": \"2008-01-01T00:00:00\", \"price\": 102.75}, {\"symbol\": \"IBM\", \"date\": \"2008-02-01T00:00:00\", \"price\": 109.64}, {\"symbol\": \"IBM\", \"date\": \"2008-03-01T00:00:00\", \"price\": 110.87}, {\"symbol\": \"IBM\", \"date\": \"2008-04-01T00:00:00\", \"price\": 116.23}, {\"symbol\": \"IBM\", \"date\": \"2008-05-01T00:00:00\", \"price\": 125.14}, {\"symbol\": \"IBM\", \"date\": \"2008-06-01T00:00:00\", \"price\": 114.6}, {\"symbol\": \"IBM\", \"date\": \"2008-07-01T00:00:00\", \"price\": 123.74}, {\"symbol\": \"IBM\", \"date\": \"2008-08-01T00:00:00\", \"price\": 118.16}, {\"symbol\": \"IBM\", \"date\": \"2008-09-01T00:00:00\", \"price\": 113.53}, {\"symbol\": \"IBM\", \"date\": \"2008-10-01T00:00:00\", \"price\": 90.24}, {\"symbol\": \"IBM\", \"date\": \"2008-11-01T00:00:00\", \"price\": 79.65}, {\"symbol\": \"IBM\", \"date\": \"2008-12-01T00:00:00\", \"price\": 82.15}, {\"symbol\": \"IBM\", \"date\": \"2009-01-01T00:00:00\", \"price\": 89.46}, {\"symbol\": \"IBM\", \"date\": \"2009-02-01T00:00:00\", \"price\": 90.32}, {\"symbol\": \"IBM\", \"date\": \"2009-03-01T00:00:00\", \"price\": 95.09}, {\"symbol\": \"IBM\", \"date\": \"2009-04-01T00:00:00\", \"price\": 101.29}, {\"symbol\": \"IBM\", \"date\": \"2009-05-01T00:00:00\", \"price\": 104.85}, {\"symbol\": \"IBM\", \"date\": \"2009-06-01T00:00:00\", \"price\": 103.01}, {\"symbol\": \"IBM\", \"date\": \"2009-07-01T00:00:00\", \"price\": 116.34}, {\"symbol\": \"IBM\", \"date\": \"2009-08-01T00:00:00\", \"price\": 117.0}, {\"symbol\": \"IBM\", \"date\": \"2009-09-01T00:00:00\", \"price\": 118.55}, {\"symbol\": \"IBM\", \"date\": \"2009-10-01T00:00:00\", \"price\": 119.54}, {\"symbol\": \"IBM\", \"date\": \"2009-11-01T00:00:00\", \"price\": 125.79}, {\"symbol\": \"IBM\", \"date\": \"2009-12-01T00:00:00\", \"price\": 130.32}, {\"symbol\": \"IBM\", \"date\": \"2010-01-01T00:00:00\", \"price\": 121.85}, {\"symbol\": \"IBM\", \"date\": \"2010-02-01T00:00:00\", \"price\": 127.16}, {\"symbol\": \"IBM\", \"date\": \"2010-03-01T00:00:00\", \"price\": 125.55}, {\"symbol\": \"GOOG\", \"date\": \"2004-08-01T00:00:00\", \"price\": 102.37}, {\"symbol\": \"GOOG\", \"date\": \"2004-09-01T00:00:00\", \"price\": 129.6}, {\"symbol\": \"GOOG\", \"date\": \"2004-10-01T00:00:00\", \"price\": 190.64}, {\"symbol\": \"GOOG\", \"date\": \"2004-11-01T00:00:00\", \"price\": 181.98}, {\"symbol\": \"GOOG\", \"date\": \"2004-12-01T00:00:00\", \"price\": 192.79}, {\"symbol\": \"GOOG\", \"date\": \"2005-01-01T00:00:00\", \"price\": 195.62}, {\"symbol\": \"GOOG\", \"date\": \"2005-02-01T00:00:00\", \"price\": 187.99}, {\"symbol\": \"GOOG\", \"date\": \"2005-03-01T00:00:00\", \"price\": 180.51}, {\"symbol\": \"GOOG\", \"date\": \"2005-04-01T00:00:00\", \"price\": 220.0}, {\"symbol\": \"GOOG\", \"date\": \"2005-05-01T00:00:00\", \"price\": 277.27}, {\"symbol\": \"GOOG\", \"date\": \"2005-06-01T00:00:00\", \"price\": 294.15}, {\"symbol\": \"GOOG\", \"date\": \"2005-07-01T00:00:00\", \"price\": 287.76}, {\"symbol\": \"GOOG\", \"date\": \"2005-08-01T00:00:00\", \"price\": 286.0}, {\"symbol\": \"GOOG\", \"date\": \"2005-09-01T00:00:00\", \"price\": 316.46}, {\"symbol\": \"GOOG\", \"date\": \"2005-10-01T00:00:00\", \"price\": 372.14}, {\"symbol\": \"GOOG\", \"date\": \"2005-11-01T00:00:00\", \"price\": 404.91}, {\"symbol\": \"GOOG\", \"date\": \"2005-12-01T00:00:00\", \"price\": 414.86}, {\"symbol\": \"GOOG\", \"date\": \"2006-01-01T00:00:00\", \"price\": 432.66}, {\"symbol\": \"GOOG\", \"date\": \"2006-02-01T00:00:00\", \"price\": 362.62}, {\"symbol\": \"GOOG\", \"date\": \"2006-03-01T00:00:00\", \"price\": 390.0}, {\"symbol\": \"GOOG\", \"date\": \"2006-04-01T00:00:00\", \"price\": 417.94}, {\"symbol\": \"GOOG\", \"date\": \"2006-05-01T00:00:00\", \"price\": 371.82}, {\"symbol\": \"GOOG\", \"date\": \"2006-06-01T00:00:00\", \"price\": 419.33}, {\"symbol\": \"GOOG\", \"date\": \"2006-07-01T00:00:00\", \"price\": 386.6}, {\"symbol\": \"GOOG\", \"date\": \"2006-08-01T00:00:00\", \"price\": 378.53}, {\"symbol\": \"GOOG\", \"date\": \"2006-09-01T00:00:00\", \"price\": 401.9}, {\"symbol\": \"GOOG\", \"date\": \"2006-10-01T00:00:00\", \"price\": 476.39}, {\"symbol\": \"GOOG\", \"date\": \"2006-11-01T00:00:00\", \"price\": 484.81}, {\"symbol\": \"GOOG\", \"date\": \"2006-12-01T00:00:00\", \"price\": 460.48}, {\"symbol\": \"GOOG\", \"date\": \"2007-01-01T00:00:00\", \"price\": 501.5}, {\"symbol\": \"GOOG\", \"date\": \"2007-02-01T00:00:00\", \"price\": 449.45}, {\"symbol\": \"GOOG\", \"date\": \"2007-03-01T00:00:00\", \"price\": 458.16}, {\"symbol\": \"GOOG\", \"date\": \"2007-04-01T00:00:00\", \"price\": 471.38}, {\"symbol\": \"GOOG\", \"date\": \"2007-05-01T00:00:00\", \"price\": 497.91}, {\"symbol\": \"GOOG\", \"date\": \"2007-06-01T00:00:00\", \"price\": 522.7}, {\"symbol\": \"GOOG\", \"date\": \"2007-07-01T00:00:00\", \"price\": 510.0}, {\"symbol\": \"GOOG\", \"date\": \"2007-08-01T00:00:00\", \"price\": 515.25}, {\"symbol\": \"GOOG\", \"date\": \"2007-09-01T00:00:00\", \"price\": 567.27}, {\"symbol\": \"GOOG\", \"date\": \"2007-10-01T00:00:00\", \"price\": 707.0}, {\"symbol\": \"GOOG\", \"date\": \"2007-11-01T00:00:00\", \"price\": 693.0}, {\"symbol\": \"GOOG\", \"date\": \"2007-12-01T00:00:00\", \"price\": 691.48}, {\"symbol\": \"GOOG\", \"date\": \"2008-01-01T00:00:00\", \"price\": 564.3}, {\"symbol\": \"GOOG\", \"date\": \"2008-02-01T00:00:00\", \"price\": 471.18}, {\"symbol\": \"GOOG\", \"date\": \"2008-03-01T00:00:00\", \"price\": 440.47}, {\"symbol\": \"GOOG\", \"date\": \"2008-04-01T00:00:00\", \"price\": 574.29}, {\"symbol\": \"GOOG\", \"date\": \"2008-05-01T00:00:00\", \"price\": 585.8}, {\"symbol\": \"GOOG\", \"date\": \"2008-06-01T00:00:00\", \"price\": 526.42}, {\"symbol\": \"GOOG\", \"date\": \"2008-07-01T00:00:00\", \"price\": 473.75}, {\"symbol\": \"GOOG\", \"date\": \"2008-08-01T00:00:00\", \"price\": 463.29}, {\"symbol\": \"GOOG\", \"date\": \"2008-09-01T00:00:00\", \"price\": 400.52}, {\"symbol\": \"GOOG\", \"date\": \"2008-10-01T00:00:00\", \"price\": 359.36}, {\"symbol\": \"GOOG\", \"date\": \"2008-11-01T00:00:00\", \"price\": 292.96}, {\"symbol\": \"GOOG\", \"date\": \"2008-12-01T00:00:00\", \"price\": 307.65}, {\"symbol\": \"GOOG\", \"date\": \"2009-01-01T00:00:00\", \"price\": 338.53}, {\"symbol\": \"GOOG\", \"date\": \"2009-02-01T00:00:00\", \"price\": 337.99}, {\"symbol\": \"GOOG\", \"date\": \"2009-03-01T00:00:00\", \"price\": 348.06}, {\"symbol\": \"GOOG\", \"date\": \"2009-04-01T00:00:00\", \"price\": 395.97}, {\"symbol\": \"GOOG\", \"date\": \"2009-05-01T00:00:00\", \"price\": 417.23}, {\"symbol\": \"GOOG\", \"date\": \"2009-06-01T00:00:00\", \"price\": 421.59}, {\"symbol\": \"GOOG\", \"date\": \"2009-07-01T00:00:00\", \"price\": 443.05}, {\"symbol\": \"GOOG\", \"date\": \"2009-08-01T00:00:00\", \"price\": 461.67}, {\"symbol\": \"GOOG\", \"date\": \"2009-09-01T00:00:00\", \"price\": 495.85}, {\"symbol\": \"GOOG\", \"date\": \"2009-10-01T00:00:00\", \"price\": 536.12}, {\"symbol\": \"GOOG\", \"date\": \"2009-11-01T00:00:00\", \"price\": 583.0}, {\"symbol\": \"GOOG\", \"date\": \"2009-12-01T00:00:00\", \"price\": 619.98}, {\"symbol\": \"GOOG\", \"date\": \"2010-01-01T00:00:00\", \"price\": 529.94}, {\"symbol\": \"GOOG\", \"date\": \"2010-02-01T00:00:00\", \"price\": 526.8}, {\"symbol\": \"GOOG\", \"date\": \"2010-03-01T00:00:00\", \"price\": 560.19}, {\"symbol\": \"AAPL\", \"date\": \"2000-01-01T00:00:00\", \"price\": 25.94}, {\"symbol\": \"AAPL\", \"date\": \"2000-02-01T00:00:00\", \"price\": 28.66}, {\"symbol\": \"AAPL\", \"date\": \"2000-03-01T00:00:00\", \"price\": 33.95}, {\"symbol\": \"AAPL\", \"date\": \"2000-04-01T00:00:00\", \"price\": 31.01}, {\"symbol\": \"AAPL\", \"date\": \"2000-05-01T00:00:00\", \"price\": 21.0}, {\"symbol\": \"AAPL\", \"date\": \"2000-06-01T00:00:00\", \"price\": 26.19}, {\"symbol\": \"AAPL\", \"date\": \"2000-07-01T00:00:00\", \"price\": 25.41}, {\"symbol\": \"AAPL\", \"date\": \"2000-08-01T00:00:00\", \"price\": 30.47}, {\"symbol\": \"AAPL\", \"date\": \"2000-09-01T00:00:00\", \"price\": 12.88}, {\"symbol\": \"AAPL\", \"date\": \"2000-10-01T00:00:00\", \"price\": 9.78}, {\"symbol\": \"AAPL\", \"date\": \"2000-11-01T00:00:00\", \"price\": 8.25}, {\"symbol\": \"AAPL\", \"date\": \"2000-12-01T00:00:00\", \"price\": 7.44}, {\"symbol\": \"AAPL\", \"date\": \"2001-01-01T00:00:00\", \"price\": 10.81}, {\"symbol\": \"AAPL\", \"date\": \"2001-02-01T00:00:00\", \"price\": 9.12}, {\"symbol\": \"AAPL\", \"date\": \"2001-03-01T00:00:00\", \"price\": 11.03}, {\"symbol\": \"AAPL\", \"date\": \"2001-04-01T00:00:00\", \"price\": 12.74}, {\"symbol\": \"AAPL\", \"date\": \"2001-05-01T00:00:00\", \"price\": 9.98}, {\"symbol\": \"AAPL\", \"date\": \"2001-06-01T00:00:00\", \"price\": 11.62}, {\"symbol\": \"AAPL\", \"date\": \"2001-07-01T00:00:00\", \"price\": 9.4}, {\"symbol\": \"AAPL\", \"date\": \"2001-08-01T00:00:00\", \"price\": 9.27}, {\"symbol\": \"AAPL\", \"date\": \"2001-09-01T00:00:00\", \"price\": 7.76}, {\"symbol\": \"AAPL\", \"date\": \"2001-10-01T00:00:00\", \"price\": 8.78}, {\"symbol\": \"AAPL\", \"date\": \"2001-11-01T00:00:00\", \"price\": 10.65}, {\"symbol\": \"AAPL\", \"date\": \"2001-12-01T00:00:00\", \"price\": 10.95}, {\"symbol\": \"AAPL\", \"date\": \"2002-01-01T00:00:00\", \"price\": 12.36}, {\"symbol\": \"AAPL\", \"date\": \"2002-02-01T00:00:00\", \"price\": 10.85}, {\"symbol\": \"AAPL\", \"date\": \"2002-03-01T00:00:00\", \"price\": 11.84}, {\"symbol\": \"AAPL\", \"date\": \"2002-04-01T00:00:00\", \"price\": 12.14}, {\"symbol\": \"AAPL\", \"date\": \"2002-05-01T00:00:00\", \"price\": 11.65}, {\"symbol\": \"AAPL\", \"date\": \"2002-06-01T00:00:00\", \"price\": 8.86}, {\"symbol\": \"AAPL\", \"date\": \"2002-07-01T00:00:00\", \"price\": 7.63}, {\"symbol\": \"AAPL\", \"date\": \"2002-08-01T00:00:00\", \"price\": 7.38}, {\"symbol\": \"AAPL\", \"date\": \"2002-09-01T00:00:00\", \"price\": 7.25}, {\"symbol\": \"AAPL\", \"date\": \"2002-10-01T00:00:00\", \"price\": 8.03}, {\"symbol\": \"AAPL\", \"date\": \"2002-11-01T00:00:00\", \"price\": 7.75}, {\"symbol\": \"AAPL\", \"date\": \"2002-12-01T00:00:00\", \"price\": 7.16}, {\"symbol\": \"AAPL\", \"date\": \"2003-01-01T00:00:00\", \"price\": 7.18}, {\"symbol\": \"AAPL\", \"date\": \"2003-02-01T00:00:00\", \"price\": 7.51}, {\"symbol\": \"AAPL\", \"date\": \"2003-03-01T00:00:00\", \"price\": 7.07}, {\"symbol\": \"AAPL\", \"date\": \"2003-04-01T00:00:00\", \"price\": 7.11}, {\"symbol\": \"AAPL\", \"date\": \"2003-05-01T00:00:00\", \"price\": 8.98}, {\"symbol\": \"AAPL\", \"date\": \"2003-06-01T00:00:00\", \"price\": 9.53}, {\"symbol\": \"AAPL\", \"date\": \"2003-07-01T00:00:00\", \"price\": 10.54}, {\"symbol\": \"AAPL\", \"date\": \"2003-08-01T00:00:00\", \"price\": 11.31}, {\"symbol\": \"AAPL\", \"date\": \"2003-09-01T00:00:00\", \"price\": 10.36}, {\"symbol\": \"AAPL\", \"date\": \"2003-10-01T00:00:00\", \"price\": 11.44}, {\"symbol\": \"AAPL\", \"date\": \"2003-11-01T00:00:00\", \"price\": 10.45}, {\"symbol\": \"AAPL\", \"date\": \"2003-12-01T00:00:00\", \"price\": 10.69}, {\"symbol\": \"AAPL\", \"date\": \"2004-01-01T00:00:00\", \"price\": 11.28}, {\"symbol\": \"AAPL\", \"date\": \"2004-02-01T00:00:00\", \"price\": 11.96}, {\"symbol\": \"AAPL\", \"date\": \"2004-03-01T00:00:00\", \"price\": 13.52}, {\"symbol\": \"AAPL\", \"date\": \"2004-04-01T00:00:00\", \"price\": 12.89}, {\"symbol\": \"AAPL\", \"date\": \"2004-05-01T00:00:00\", \"price\": 14.03}, {\"symbol\": \"AAPL\", \"date\": \"2004-06-01T00:00:00\", \"price\": 16.27}, {\"symbol\": \"AAPL\", \"date\": \"2004-07-01T00:00:00\", \"price\": 16.17}, {\"symbol\": \"AAPL\", \"date\": \"2004-08-01T00:00:00\", \"price\": 17.25}, {\"symbol\": \"AAPL\", \"date\": \"2004-09-01T00:00:00\", \"price\": 19.38}, {\"symbol\": \"AAPL\", \"date\": \"2004-10-01T00:00:00\", \"price\": 26.2}, {\"symbol\": \"AAPL\", \"date\": \"2004-11-01T00:00:00\", \"price\": 33.53}, {\"symbol\": \"AAPL\", \"date\": \"2004-12-01T00:00:00\", \"price\": 32.2}, {\"symbol\": \"AAPL\", \"date\": \"2005-01-01T00:00:00\", \"price\": 38.45}, {\"symbol\": \"AAPL\", \"date\": \"2005-02-01T00:00:00\", \"price\": 44.86}, {\"symbol\": \"AAPL\", \"date\": \"2005-03-01T00:00:00\", \"price\": 41.67}, {\"symbol\": \"AAPL\", \"date\": \"2005-04-01T00:00:00\", \"price\": 36.06}, {\"symbol\": \"AAPL\", \"date\": \"2005-05-01T00:00:00\", \"price\": 39.76}, {\"symbol\": \"AAPL\", \"date\": \"2005-06-01T00:00:00\", \"price\": 36.81}, {\"symbol\": \"AAPL\", \"date\": \"2005-07-01T00:00:00\", \"price\": 42.65}, {\"symbol\": \"AAPL\", \"date\": \"2005-08-01T00:00:00\", \"price\": 46.89}, {\"symbol\": \"AAPL\", \"date\": \"2005-09-01T00:00:00\", \"price\": 53.61}, {\"symbol\": \"AAPL\", \"date\": \"2005-10-01T00:00:00\", \"price\": 57.59}, {\"symbol\": \"AAPL\", \"date\": \"2005-11-01T00:00:00\", \"price\": 67.82}, {\"symbol\": \"AAPL\", \"date\": \"2005-12-01T00:00:00\", \"price\": 71.89}, {\"symbol\": \"AAPL\", \"date\": \"2006-01-01T00:00:00\", \"price\": 75.51}, {\"symbol\": \"AAPL\", \"date\": \"2006-02-01T00:00:00\", \"price\": 68.49}, {\"symbol\": \"AAPL\", \"date\": \"2006-03-01T00:00:00\", \"price\": 62.72}, {\"symbol\": \"AAPL\", \"date\": \"2006-04-01T00:00:00\", \"price\": 70.39}, {\"symbol\": \"AAPL\", \"date\": \"2006-05-01T00:00:00\", \"price\": 59.77}, {\"symbol\": \"AAPL\", \"date\": \"2006-06-01T00:00:00\", \"price\": 57.27}, {\"symbol\": \"AAPL\", \"date\": \"2006-07-01T00:00:00\", \"price\": 67.96}, {\"symbol\": \"AAPL\", \"date\": \"2006-08-01T00:00:00\", \"price\": 67.85}, {\"symbol\": \"AAPL\", \"date\": \"2006-09-01T00:00:00\", \"price\": 76.98}, {\"symbol\": \"AAPL\", \"date\": \"2006-10-01T00:00:00\", \"price\": 81.08}, {\"symbol\": \"AAPL\", \"date\": \"2006-11-01T00:00:00\", \"price\": 91.66}, {\"symbol\": \"AAPL\", \"date\": \"2006-12-01T00:00:00\", \"price\": 84.84}, {\"symbol\": \"AAPL\", \"date\": \"2007-01-01T00:00:00\", \"price\": 85.73}, {\"symbol\": \"AAPL\", \"date\": \"2007-02-01T00:00:00\", \"price\": 84.61}, {\"symbol\": \"AAPL\", \"date\": \"2007-03-01T00:00:00\", \"price\": 92.91}, {\"symbol\": \"AAPL\", \"date\": \"2007-04-01T00:00:00\", \"price\": 99.8}, {\"symbol\": \"AAPL\", \"date\": \"2007-05-01T00:00:00\", \"price\": 121.19}, {\"symbol\": \"AAPL\", \"date\": \"2007-06-01T00:00:00\", \"price\": 122.04}, {\"symbol\": \"AAPL\", \"date\": \"2007-07-01T00:00:00\", \"price\": 131.76}, {\"symbol\": \"AAPL\", \"date\": \"2007-08-01T00:00:00\", \"price\": 138.48}, {\"symbol\": \"AAPL\", \"date\": \"2007-09-01T00:00:00\", \"price\": 153.47}, {\"symbol\": \"AAPL\", \"date\": \"2007-10-01T00:00:00\", \"price\": 189.95}, {\"symbol\": \"AAPL\", \"date\": \"2007-11-01T00:00:00\", \"price\": 182.22}, {\"symbol\": \"AAPL\", \"date\": \"2007-12-01T00:00:00\", \"price\": 198.08}, {\"symbol\": \"AAPL\", \"date\": \"2008-01-01T00:00:00\", \"price\": 135.36}, {\"symbol\": \"AAPL\", \"date\": \"2008-02-01T00:00:00\", \"price\": 125.02}, {\"symbol\": \"AAPL\", \"date\": \"2008-03-01T00:00:00\", \"price\": 143.5}, {\"symbol\": \"AAPL\", \"date\": \"2008-04-01T00:00:00\", \"price\": 173.95}, {\"symbol\": \"AAPL\", \"date\": \"2008-05-01T00:00:00\", \"price\": 188.75}, {\"symbol\": \"AAPL\", \"date\": \"2008-06-01T00:00:00\", \"price\": 167.44}, {\"symbol\": \"AAPL\", \"date\": \"2008-07-01T00:00:00\", \"price\": 158.95}, {\"symbol\": \"AAPL\", \"date\": \"2008-08-01T00:00:00\", \"price\": 169.53}, {\"symbol\": \"AAPL\", \"date\": \"2008-09-01T00:00:00\", \"price\": 113.66}, {\"symbol\": \"AAPL\", \"date\": \"2008-10-01T00:00:00\", \"price\": 107.59}, {\"symbol\": \"AAPL\", \"date\": \"2008-11-01T00:00:00\", \"price\": 92.67}, {\"symbol\": \"AAPL\", \"date\": \"2008-12-01T00:00:00\", \"price\": 85.35}, {\"symbol\": \"AAPL\", \"date\": \"2009-01-01T00:00:00\", \"price\": 90.13}, {\"symbol\": \"AAPL\", \"date\": \"2009-02-01T00:00:00\", \"price\": 89.31}, {\"symbol\": \"AAPL\", \"date\": \"2009-03-01T00:00:00\", \"price\": 105.12}, {\"symbol\": \"AAPL\", \"date\": \"2009-04-01T00:00:00\", \"price\": 125.83}, {\"symbol\": \"AAPL\", \"date\": \"2009-05-01T00:00:00\", \"price\": 135.81}, {\"symbol\": \"AAPL\", \"date\": \"2009-06-01T00:00:00\", \"price\": 142.43}, {\"symbol\": \"AAPL\", \"date\": \"2009-07-01T00:00:00\", \"price\": 163.39}, {\"symbol\": \"AAPL\", \"date\": \"2009-08-01T00:00:00\", \"price\": 168.21}, {\"symbol\": \"AAPL\", \"date\": \"2009-09-01T00:00:00\", \"price\": 185.35}, {\"symbol\": \"AAPL\", \"date\": \"2009-10-01T00:00:00\", \"price\": 188.5}, {\"symbol\": \"AAPL\", \"date\": \"2009-11-01T00:00:00\", \"price\": 199.91}, {\"symbol\": \"AAPL\", \"date\": \"2009-12-01T00:00:00\", \"price\": 210.73}, {\"symbol\": \"AAPL\", \"date\": \"2010-01-01T00:00:00\", \"price\": 192.06}, {\"symbol\": \"AAPL\", \"date\": \"2010-02-01T00:00:00\", \"price\": 204.62}, {\"symbol\": \"AAPL\", \"date\": \"2010-03-01T00:00:00\", \"price\": 223.02}]}}, {\"mode\": \"vega-lite\"});\n",
+       "</script>"
+      ],
+      "text/plain": [
+       "alt.Chart(...)"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Display selected chart\n",
+    "charts = {\n",
+    "    \"Scatter: Horsepower vs MPG\": scatter,\n",
+    "    \"Line: Stock Prices\": line,\n",
+    "    \"Bar: Seattle Precipitation\": bar,\n",
+    "}\n",
+    "\n",
+    "charts[chart_select.value]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "02d11506-bd65-4b25-85e8-daf0484479c6",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/src/content/docs/examples/altair-dark-plots.mdx
+++ b/docs/src/content/docs/examples/altair-dark-plots.mdx
@@ -1,0 +1,195 @@
+---
+title: Dark Theme Altair Charts
+description: Build an interactive Mercury app with beautiful dark-themed Altair visualizations.
+---
+
+import { Steps } from '@astrojs/starlight/components';
+
+# Dark Theme Altair Charts
+
+This tutorial shows you how to create a Mercury web app with interactive, dark-themed [Altair](https://altair-viz.github.io/) charts. You'll register a custom dark theme, add Mercury widgets to let users switch charts and toggle the theme, and serve everything as a polished web app.
+
+## What you'll build
+
+A single-notebook Mercury app with:
+- A **dropdown** to switch between three chart types (scatter, line, bar)
+- A **checkbox** to toggle the dark theme on/off
+- Three fully interactive Altair charts styled to match Mercury's dark UI
+
+## Prerequisites
+
+```bash
+pip install mercury altair vega_datasets pandas
+```
+
+---
+
+## Step 1 — Register a dark Altair theme
+
+Altair's theme system lets you define default styles for every chart. Add this near the top of your notebook:
+
+```python
+import altair as alt
+
+def dark_theme():
+    return {
+        "config": {
+            "background": "#1e1e2e",
+            "view": {"stroke": "transparent"},
+            "title": {"color": "#cdd6f4", "fontSize": 16},
+            "axis": {
+                "domainColor": "#45475a",
+                "gridColor": "#313244",
+                "labelColor": "#bac2de",
+                "tickColor": "#45475a",
+                "titleColor": "#cdd6f4",
+            },
+            "legend": {
+                "labelColor": "#bac2de",
+                "titleColor": "#cdd6f4",
+            },
+            "range": {
+                "category": ["#89b4fa", "#a6e3a1", "#fab387", "#f38ba8", "#cba6f7", "#94e2d5"],
+            },
+        }
+    }
+
+alt.themes.register("dark", dark_theme)
+alt.themes.enable("dark")
+```
+
+The color palette here uses [Catppuccin Mocha](https://github.com/catppuccin/catppuccin) tones, which complement Mercury's default dark UI nicely. Feel free to swap in any hex values you prefer.
+
+---
+
+## Step 2 — Add Mercury widgets
+
+```python
+import mercury as mr
+
+chart_select = mr.Select(
+    value="Scatter: Horsepower vs MPG",
+    choices=["Scatter: Horsepower vs MPG", "Line: Stock Prices", "Bar: Seattle Precipitation"],
+    label="Choose Chart",
+)
+
+use_dark = mr.Checkbox(value=True, label="Dark Theme")
+```
+
+`mr.Select` renders as a dropdown in the sidebar. `mr.Checkbox` adds a toggle. When a user changes either widget, Mercury re-executes the notebook cells automatically.
+
+---
+
+## Step 3 — Conditionally apply the theme
+
+In a cell after the widgets, apply or remove the theme based on the checkbox value:
+
+```python
+if use_dark.value:
+    alt.themes.enable("dark")
+else:
+    alt.themes.enable("default")
+```
+
+---
+
+## Step 4 — Create the charts
+
+### Scatter — Horsepower vs MPG
+
+```python
+from vega_datasets import data
+
+cars = data.cars()
+
+scatter = (
+    alt.Chart(cars)
+    .mark_circle(size=70, opacity=0.85)
+    .encode(
+        x=alt.X("Horsepower:Q", title="Horsepower"),
+        y=alt.Y("Miles_per_Gallon:Q", title="Miles per Gallon"),
+        color=alt.Color("Origin:N", legend=alt.Legend(title="Origin")),
+        tooltip=["Name", "Horsepower", "Miles_per_Gallon", "Origin"],
+    )
+    .properties(title="Horsepower vs Miles per Gallon", width=600, height=350)
+    .interactive()
+)
+```
+
+### Line — Stock prices over time
+
+```python
+stocks = data.stocks()
+
+line = (
+    alt.Chart(stocks)
+    .mark_line(strokeWidth=2)
+    .encode(
+        x=alt.X("date:T", title="Date"),
+        y=alt.Y("price:Q", title="Price (USD)"),
+        color=alt.Color("symbol:N", legend=alt.Legend(title="Stock")),
+        tooltip=["symbol", "date", "price"],
+    )
+    .properties(title="Stock Prices Over Time", width=600, height=350)
+    .interactive()
+)
+```
+
+### Bar — Seattle monthly precipitation
+
+```python
+import pandas as pd
+
+seattle = data.seattle_weather()
+seattle["month"] = pd.to_datetime(seattle["date"]).dt.strftime("%b")
+month_order = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"]
+monthly_precip = seattle.groupby("month", as_index=False)["precipitation"].mean()
+
+bar = (
+    alt.Chart(monthly_precip)
+    .mark_bar(cornerRadiusTopLeft=3, cornerRadiusTopRight=3)
+    .encode(
+        x=alt.X("month:N", sort=month_order, title="Month"),
+        y=alt.Y("precipitation:Q", title="Avg Precipitation (mm)"),
+        color=alt.Color("precipitation:Q", scale=alt.Scale(scheme="blues"), legend=None),
+        tooltip=["month", alt.Tooltip("precipitation:Q", format=".2f")],
+    )
+    .properties(title="Seattle: Average Monthly Precipitation", width=600, height=350)
+)
+```
+
+---
+
+## Step 5 — Display the selected chart
+
+```python
+charts = {
+    "Scatter: Horsepower vs MPG": scatter,
+    "Line: Stock Prices": line,
+    "Bar: Seattle Precipitation": bar,
+}
+
+charts[chart_select.value]
+```
+
+Mercury re-runs the notebook whenever the dropdown or checkbox changes, so this cell always renders the right chart with the right theme.
+
+---
+
+## Run the app
+
+```bash
+mercury altair_dark_theme.ipynb
+```
+
+Open [http://localhost:8888](http://localhost:8888) and you'll see the sidebar with your widgets on the left and the chart on the right.
+
+---
+
+## Tips
+
+- **Custom color schemes** — swap out `"blues"` in the bar chart's `Scale` for any [Vega color scheme](https://vega.github.io/vega/docs/schemes/).
+- **More widgets** — add `mr.Slider` to filter data ranges before rendering (e.g., filter cars by year).
+- **Dark background in the page** — Mercury's dark UI wraps the chart automatically; no extra CSS needed.
+- **Export** — the chart's built-in toolbar (top-right ⋯ menu) lets users download the chart as SVG or PNG.
+


### PR DESCRIPTION
Closes #559

## What's added
- Example notebook `altair_dark_theme.ipynb` with 3 interactive Altair charts in dark theme (scatter, line, bar)
- Custom dark theme registered via `alt.themes.register`
- Mercury widgets: dropdown to switch charts, checkbox to toggle theme on/off
- Docs tutorial page at `examples/altair-dark-plots`
- Screenshots of all 3 charts

## Screenshots
<img width="715" height="417" alt="visualization (2)" src="https://github.com/user-attachments/assets/b5feaf1e-4483-49e0-9143-7a342fa755da" />
<img width="711" height="417" alt="visualization (1)" src="https://github.com/user-attachments/assets/b6493f1b-ad33-41d0-bb9f-8c2c34343ba0" />
<img width="646" height="426" alt="visualization" src="https://github.com/user-attachments/assets/c8f27672-de48-4b1d-ab2a-6cd3a9f232b4" />
