### PR TITLE
docs: add dark matplotlib plots tutorial

### DIFF
--- a/docs/notebooks/dark-matplotlib-plots.ipynb
+++ b/docs/notebooks/dark-matplotlib-plots.ipynb
@@ -1,0 +1,233 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Dark Theme Matplotlib Plots in Mercury\n",
+    "\n",
+    "This tutorial shows how to create beautiful dark theme matplotlib plots and use them in Mercury apps.\n",
+    "\n",
+    "Dark theme plots are perfect for:\n",
+    "- Dashboards with dark backgrounds\n",
+    "- Presentations and reports\n",
+    "- Reducing eye strain in low-light environments"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Install the required libraries:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Install dependencies\n",
+    "# pip install mercury matplotlib numpy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import mercury as mr\n",
+    "import matplotlib.pyplot as plt\n",
+    "import matplotlib\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Mercury App Configuration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "app = mr.App(\n",
+    "    title=\"Dark Matplotlib Plots\",\n",
+    "    description=\"Tutorial: Dark theme matplotlib plots in Mercury\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Available Dark Styles\n",
+    "\n",
+    "Matplotlib comes with several built-in dark styles:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# View all available dark styles\n",
+    "dark_styles = [s for s in plt.style.available if 'dark' in s.lower()]\n",
+    "print('Available dark styles:', dark_styles)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Method 1: Using dark_background style"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Select chart type\n",
+    "chart_type = mr.Select(\n",
+    "    value=\"Line\",\n",
+    "    choices=[\"Line\", \"Bar\", \"Scatter\"],\n",
+    "    label=\"Chart Type\"\n",
+    ")\n",
+    "\n",
+    "# Select dark style\n",
+    "dark_style = mr.Select(\n",
+    "    value=\"dark_background\",\n",
+    "    choices=[\"dark_background\", \"Solarize_Light2\"],\n",
+    "    label=\"Dark Style\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Generate sample data\n",
+    "x = np.linspace(0, 10, 100)\n",
+    "y1 = np.sin(x)\n",
+    "y2 = np.cos(x)\n",
+    "y3 = np.sin(x) * np.cos(x)\n",
+    "\n",
+    "# Apply selected dark style\n",
+    "with plt.style.context(dark_style.value):\n",
+    "    fig, ax = plt.subplots(figsize=(10, 5))\n",
+    "\n",
+    "    if chart_type.value == \"Line\":\n",
+    "        ax.plot(x, y1, color='#7C3AED', linewidth=2, label='sin(x)')\n",
+    "        ax.plot(x, y2, color='#38BDF8', linewidth=2, label='cos(x)')\n",
+    "        ax.plot(x, y3, color='#34D399', linewidth=2, label='sin(x)cos(x)')\n",
+    "    elif chart_type.value == \"Bar\":\n",
+    "        categories = ['A', 'B', 'C', 'D', 'E']\n",
+    "        values = np.random.randint(10, 100, 5)\n",
+    "        colors = ['#7C3AED', '#38BDF8', '#34D399', '#F59E0B', '#EC4899']\n",
+    "        ax.bar(categories, values, color=colors)\n",
+    "    elif chart_type.value == \"Scatter\":\n",
+    "        scatter_x = np.random.randn(100)\n",
+    "        scatter_y = np.random.randn(100)\n",
+    "        ax.scatter(scatter_x, scatter_y, color='#7C3AED', alpha=0.6, s=50)\n",
+    "\n",
+    "    ax.set_title(f'Dark Theme {chart_type.value} Chart', fontsize=14, pad=15)\n",
+    "    ax.set_xlabel('X Axis')\n",
+    "    ax.set_ylabel('Y Axis')\n",
+    "    if chart_type.value == \"Line\":\n",
+    "        ax.legend()\n",
+    "    ax.grid(True, alpha=0.3)\n",
+    "    plt.tight_layout()\n",
+    "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Method 2: Custom Dark Theme\n",
+    "\n",
+    "You can also create a fully custom dark theme:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Custom dark theme settings\n",
+    "custom_dark = {\n",
+    "    'figure.facecolor': '#0f0f0f',\n",
+    "    'axes.facecolor': '#1a1a1a',\n",
+    "    'axes.edgecolor': '#333333',\n",
+    "    'axes.labelcolor': '#ffffff',\n",
+    "    'text.color': '#ffffff',\n",
+    "    'xtick.color': '#6B7280',\n",
+    "    'ytick.color': '#6B7280',\n",
+    "    'grid.color': '#333333',\n",
+    "    'grid.alpha': 0.5\n",
+    "}\n",
+    "\n",
+    "with matplotlib.rc_context(custom_dark):\n",
+    "    fig, axes = plt.subplots(1, 2, figsize=(12, 5))\n",
+    "\n",
+    "    # Plot 1 - Line chart\n",
+    "    axes[0].plot(x, y1, color='#A78BFA', linewidth=2)\n",
+    "    axes[0].fill_between(x, y1, alpha=0.2, color='#A78BFA')\n",
+    "    axes[0].set_title('Custom Dark Line Chart', color='#ffffff')\n",
+    "    axes[0].grid(True)\n",
+    "\n",
+    "    # Plot 2 - Bar chart\n",
+    "    categories = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri']\n",
+    "    values = [23, 45, 32, 67, 54]\n",
+    "    bars = axes[1].bar(categories, values,\n",
+    "                       color=['#A78BFA', '#38BDF8', '#34D399',\n",
+    "                              '#F59E0B', '#EC4899'])\n",
+    "    axes[1].set_title('Custom Dark Bar Chart', color='#ffffff')\n",
+    "    axes[1].grid(True, axis='y')\n",
+    "\n",
+    "    plt.tight_layout()\n",
+    "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "You can create dark matplotlib plots in Mercury using:\n",
+    "\n",
+    "1. **Built-in styles** - `plt.style.use('dark_background')` for quick dark themes\n",
+    "2. **Custom themes** - Use `matplotlib.rc_context()` for full control over colors\n",
+    "\n",
+    "Both methods work perfectly with Mercury widgets for interactive dark dashboards."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Summary
Adds a new tutorial notebook showing how to create dark 
theme matplotlib plots in Mercury apps.

## What's included
- Overview of built-in dark matplotlib styles (dark_background, Solarize_Light2)
- Interactive example with Line, Bar, and Scatter charts using Mercury Select widget
- Custom dark theme using matplotlib.rc_context() with full color control
- Two complete working examples with custom color palettes

## Related Issue
Closes #558