### PR TITLE
feat: add notebooks_button_label config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ To do this, create a file called `config.toml` in the active notebooks directory
 title = "Mercury"
 footer = "MLJAR - next generation of AI tools"
 favicon_emoji = "🎉"
+notebooks_button_label = "Notebooks"
 
 [welcome]
 header = ""
@@ -182,6 +183,7 @@ message = ""
 * **`title`** – the title of your web app
 * **`footer`** – text shown at the bottom of the page
 * **`favicon_emoji`** – emoji shown as the browser tab icon
+* **`notebooks_button_label`** – label shown on the notebooks dropdown button in the navbar
 * **`welcome.header`** – optional welcome header
 * **`welcome.message`** – optional welcome message for users
 

--- a/example.config.toml
+++ b/example.config.toml
@@ -2,6 +2,7 @@
 title = "(Mercury) 123"
 footer = "MLJAR - next generation of AI tools 123"
 favicon_emoji = "🎉"
+notebooks_button_label = "Notebooks"
 
 [welcome]
 header = ""

--- a/mercury_app/handlers.py
+++ b/mercury_app/handlers.py
@@ -67,6 +67,7 @@ class MercuryHandler(ExtensionHandlerJinjaMixin, ExtensionHandlerMixin, JupyterH
             "frontendUrl": ujoin(self.base_url, "mercury/"),
             "notebookPath": notebook_path,
             "title": MAIN_CONFIG.get("title", "Mercury"),
+            "notebooksButtonLabel": MAIN_CONFIG.get("notebooks_button_label", "Notebooks"),
             "mercuryStandalone": True,
             "themeCssVars": build_theme_css_vars(THEME),
             "themeFontLinks": build_theme_font_links(THEME),

--- a/mercury_app/root.py
+++ b/mercury_app/root.py
@@ -26,6 +26,7 @@ class RootIndexHandler(JupyterHandler):
                 notebooks=[],
                 base_url=base,
                 error=f"Notebooks directory '{notebooks_dir}' does not exist.",
+                notebooks_button_label=MAIN_CONFIG.get("notebooks_button_label", "Notebooks"),
                 theme=THEME,
                 theme_css_vars=build_theme_css_vars(THEME),
                 theme_font_links=build_theme_font_links(THEME),
@@ -69,6 +70,7 @@ class RootIndexHandler(JupyterHandler):
                                     footer=MAIN_CONFIG.get("footer", "MLJAR - next generation of AI tools"),
                                     header=WELCOME_CONFIG.get("header", "Hi there! 👋"),
                                     message=WELCOME_CONFIG.get("message", default_welcome_msg),
+                                    notebooks_button_label=MAIN_CONFIG.get("notebooks_button_label", "Notebooks"),
                                     theme=THEME,
                                     theme_css_vars=build_theme_css_vars(THEME),
                                     theme_font_links=build_theme_font_links(THEME))

--- a/mercury_app/templates/root.html
+++ b/mercury_app/templates/root.html
@@ -185,7 +185,7 @@
       {% if notebooks %}
       <div style="position:relative">
         <button id="nbBtn" type="button" class="btn" aria-haspopup="menu" aria-expanded="false">
-          Notebooks
+         {{ notebooks_button_label or 'Notebooks' }}
           <svg class="caret" id="nbCaret" width="16" height="16" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
             <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 10.94l3.71-3.71a.75.75 0 0 1 1.08 1.04l-4.25 4.25a.75.75 0 0 1-1.06 0L5.21 8.27a.75.75 0 0 1 .02-1.06z" clip-rule="evenodd"/>
           </svg>
@@ -220,7 +220,7 @@
 
       {% if notebooks %}
       <div class="toprow">
-        <h2 class="section-title">Notebooks</h2>
+        <h2 class="section-title">{{ notebooks_button_label or 'Notebooks' }}</h2>
         <div class="search-wrap">
           <label for="nb-search" class="hidden">Search notebooks</label>
           <input id="nb-search" class="search" placeholder="Search notebooks…" />

--- a/packages/application/src/plugins/mercury.ts
+++ b/packages/application/src/plugins/mercury.ts
@@ -68,6 +68,7 @@ export const plugin: JupyterFrontEndPlugin<void> = {
               const navbar = new MercuryNavbar({
                 baseUrl,
                 title: PageConfig.getOption('title') || 'Mercury',
+                notebooksButtonLabel: PageConfig.getOption('notebooksButtonLabel') || 'Notebooks',
                 apiUrl: `${baseUrl}mercury/api/notebooks`,
                 onHeightChange: px => {
                   // add top padding below fixed header

--- a/packages/application/src/plugins/navbar.ts
+++ b/packages/application/src/plugins/navbar.ts
@@ -14,6 +14,8 @@ export type MercuryNavbarOptions = {
   baseUrl: string;
   /** Title from PageConfig.getOption('title') */
   title: string;
+   /** Label for the notebooks dropdown button */
+  notebooksButtonLabel?: string;
   /** URL that returns the notebooks JSON array */
   apiUrl: string;
   /** Callback fired when the header height is known/changes (e.g., mount) */
@@ -178,7 +180,7 @@ export class MercuryNavbar {
     btn.id = 'mrcNbBtn';
     btn.setAttribute('aria-haspopup', 'menu');
     btn.setAttribute('aria-expanded', 'false');
-    btn.textContent = 'Notebooks';
+    btn.textContent = this.opts.notebooksButtonLabel || 'Notebooks';
 
     const caret = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
     caret.setAttribute('class', 'mrc-caret');


### PR DESCRIPTION
## What
Adds a new `notebooks_button_label` option to `[main]` in `config.toml`, letting users customize the "Notebooks" label instead of it being hardcoded.

Closes #570

## Where it was hardcoded (and fixed)
- `packages/application/src/plugins/navbar.ts` – in-app navbar dropdown button
- `packages/application/src/plugins/mercury.ts` – passes the config value into the navbar
- `mercury_app/handlers.py` – exposes the value via page_config
- `mercury_app/root.py` – passes the value into both root.html render calls
- `mercury_app/templates/root.html` – root index page button + section heading
- `example.config.toml` – added the new field with default value
- `README.md` – documented the new option in the config example and the "What you can customize" list

## Default behavior
If `notebooks_button_label` is not set, it defaults to `"Notebooks"` everywhere, so existing setups are unaffected