### PR TITLE
docs: add notebooks_button_label to customization docs

### DIFF
--- a/docs/src/content/docs/docs/customization.mdx
+++ b/docs/src/content/docs/docs/customization.mdx
@@ -15,6 +15,7 @@ Mercury apps can be customized with a `config.toml` file placed in the active no
 title = "Mercury"
 footer = "MLJAR - next generation of AI tools"
 favicon_emoji = "🎉"
+notebooks_button_label = "Notebooks"
 
 [welcome]
 header = "Welcome"
@@ -26,6 +27,7 @@ Available settings:
 - `main.title` - title shown in the app navbar and listing page
 - `main.footer` - footer text
 - `main.favicon_emoji` - emoji used as the browser tab icon
+- `main.notebooks_button_label` - label shown on the notebooks dropdown button in the navbar
 - `welcome.header` - optional welcome header on the notebook listing page
 - `welcome.message` - optional welcome message on the notebook listing page
 


### PR DESCRIPTION
Documents the `notebooks_button_label` config option (added in #572) in customization.mdx, which was missing it.
