### PR TITLE
feat: make notebook search filter configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ title = "Mercury"
 footer = "MLJAR - next generation of AI tools"
 favicon_emoji = "🎉"
 notebooks_button_label = "Notebooks"
+search_filter_label = "Search notebooks"
+show_search_filter = true
 thumbnail_text = "📘"
 thumbnail_bg = "#f1f5f9"
 thumbnail_text_color = "#0f172a"
@@ -187,9 +189,11 @@ message = ""
 * **`footer`** – text shown at the bottom of the page
 * **`favicon_emoji`** – emoji shown as the browser tab icon
 * **`notebooks_button_label`** – label shown on the notebooks dropdown button in the navbar
-* **`thumbnail_text`** – default text or emoji shown on notebook thumbnails in the listing page
-* **`thumbnail_bg`** – default thumbnail background color for notebooks in the listing page
-* **`thumbnail_text_color`** – default thumbnail text color for notebooks in the listing page
+* **`search_filter_label`** – label and placeholder shown in the notebook search field
+* **`show_search_filter`** – whether the notebook search field should be displayed
+* **`thumbnail_text`** – emoji or text displayed on notebook thumbnails
+* **`thumbnail_bg`** – background color for notebook thumbnails
+* **`thumbnail_text_color`** – text color for notebook thumbnails
 * **`welcome.header`** – optional welcome header
 * **`welcome.message`** – optional welcome message for users
 

--- a/docs/src/content/docs/docs/customization.mdx
+++ b/docs/src/content/docs/docs/customization.mdx
@@ -16,6 +16,8 @@ title = "Mercury"
 footer = "MLJAR - next generation of AI tools"
 favicon_emoji = "🎉"
 notebooks_button_label = "Notebooks"
+search_filter_label = "Search notebooks"
+show_search_filter = true
 thumbnail_text = "📘"
 thumbnail_bg = "#f1f5f9"
 thumbnail_text_color = "#0f172a"
@@ -31,9 +33,11 @@ Available settings:
 - `main.footer` - footer text
 - `main.favicon_emoji` - emoji used as the browser tab icon
 - `main.notebooks_button_label` - label shown on the notebooks dropdown button in the navbar
-- `main.thumbnail_text` - default text or emoji shown on notebook thumbnails in the listing page
-- `main.thumbnail_bg` - default thumbnail background color for notebooks in the listing page
-- `main.thumbnail_text_color` - default thumbnail text color for notebooks in the listing page
+- `main.search_filter_label` - label and placeholder shown in the notebook search field
+- `main.show_search_filter` - whether the notebook search field should be displayed
+- `main.thumbnail_text` - emoji or text displayed on notebook thumbnails
+- `main.thumbnail_bg` - background color for notebook thumbnails
+- `main.thumbnail_text_color` - text color for notebook thumbnails
 - `welcome.header` - optional welcome header on the notebook listing page
 - `welcome.message` - optional welcome message on the notebook listing page
 

--- a/example.config.toml
+++ b/example.config.toml
@@ -4,6 +4,9 @@ footer = "MLJAR - next generation of AI tools 123"
 favicon_emoji = "🎉"
 notebooks_button_label = "Notebooks"
 
+search_filter_label = "Search notebooks"
+show_search_filter = true
+
 [welcome]
 header = ""
 message = ""

--- a/mercury_app/root.py
+++ b/mercury_app/root.py
@@ -65,12 +65,34 @@ class RootIndexHandler(JupyterHandler):
         <p class="lead2">Feel free to interact and explore - everything is designed to be <b>simple and safe</b>.</p>
         """
 
-        html = self.render_template("root.html", notebooks=notebooks, base_url=base, 
-                                    title=MAIN_CONFIG.get("title", "Mercury"),           
-                                    footer=MAIN_CONFIG.get("footer", "MLJAR - next generation of AI tools"),
+        html = self.render_template("root.html", notebooks=notebooks,
+                                    base_url=base,
+                                    title=MAIN_CONFIG.get("title", "Mercury"),
+                                    footer=MAIN_CONFIG.get(
+                                        "footer",
+                                        "MLJAR - next generation of AI tools",
+                                    ),
                                     header=WELCOME_CONFIG.get("header", "Hi there! 👋"),
-                                    message=WELCOME_CONFIG.get("message", default_welcome_msg),
-                                    notebooks_button_label=MAIN_CONFIG.get("notebooks_button_label", "Notebooks"),
+                                    message=WELCOME_CONFIG.get(
+                                        "message",
+                                        default_welcome_msg,
+                                    ),
+                                    notebooks_button_label=MAIN_CONFIG.get(
+                                        "notebooks_button_label",
+                                        "Notebooks",
+                                    ),
+                                    notebooks_button_label=MAIN_CONFIG.get(
+                                        "notebooks_button_label",
+                                        "Notebooks",
+                                    ),
+                                    search_filter_label=MAIN_CONFIG.get(
+                                        "search_filter_label",
+                                        "Search notebooks",
+                                    ),
+                                    show_search_filter=MAIN_CONFIG.get(
+                                        "show_search_filter",
+                                        True,
+                                    ),
                                     theme=THEME,
                                     theme_css_vars=build_theme_css_vars(THEME),
                                     theme_font_links=build_theme_font_links(THEME))

--- a/mercury_app/templates/root.html
+++ b/mercury_app/templates/root.html
@@ -218,18 +218,34 @@
         
       </section>
 
-      {% if notebooks %}
-      <div class="toprow">
-        <h2 class="section-title">{{ notebooks_button_label or 'Notebooks' }}</h2>
-        <div class="search-wrap">
-          <label for="nb-search" class="hidden">Search notebooks</label>
-          <input id="nb-search" class="search" placeholder="Search notebooks…" />
-          <div class="search-ico" aria-hidden="true">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
-              <path d="M21 21l-4.3-4.3" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
-              <circle cx="11" cy="11" r="6.5" stroke="currentColor" stroke-width="1.6"/>
-            </svg>
-          </div>
+      {% if show_search_filter %}
+      <div class="search-wrap">
+        <label for="nb-search" class="hidden">
+          {{ search_filter_label or "Search notebooks" }}
+        </label>
+
+        <input
+          id="nb-search"
+          class="search"
+          placeholder="{{ search_filter_label or 'Search notebooks' }}"
+        />
+
+        <div class="search-ico" aria-hidden="true">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
+            <path
+              d="M21 21l-4.3-4.3"
+              stroke="currentColor"
+              stroke-width="1.6"
+              stroke-linecap="round"
+            />
+            <circle
+              cx="11"
+              cy="11"
+              r="6.5"
+              stroke="currentColor"
+              stroke-width="1.6"
+            />
+          </svg>
         </div>
       </div>
       {% endif %}


### PR DESCRIPTION
Closes #577

## Summary

Adds support for customizing the notebook search filter through `config.toml`, following the same pattern as `notebooks_button_label`.

### Changes

* Added `main.search_filter_label` to customize the search field label and placeholder.
* Added `main.show_search_filter` to optionally hide the search field.
* Updated `README.md` and customization documentation.
* Updated `example.config.toml` with the new configuration options.

### Example

```toml
[main]
search_filter_label = "Find examples"
show_search_filter = true
```

To hide the search filter entirely:

```toml
[main]
show_search_filter = false
```
