### PR TITLE
Add rows parameter to TextInput for multi-line text

### DIFF
--- a/docs/src/content/docs/docs/input/textinput.mdx
+++ b/docs/src/content/docs/docs/input/textinput.mdx
@@ -7,8 +7,9 @@ import { Code } from '@astrojs/starlight/components';
 import { Aside } from '@astrojs/starlight/components';
 import MercuryDemo from '../../../../components/MercuryDemoIframe.astro'
 
-The **TextInput** widget displays a single-line text input field.
+The **TextInput** widget displays a text input field.
 It is useful for entering names, labels, filters, search queries, or any short text values in your Mercury App.
+By default it is a single-line input; set `rows` to a value greater than `1` to get a multi-line textarea.
 
 ## Live Demo
 
@@ -64,6 +65,23 @@ text.value
 
 ```text
 Warsaw
+```
+
+---
+
+### Multi-line Text
+
+Set `rows` to a value greater than `1` to render the widget as a resizable textarea.
+
+**Code**
+
+```python
+notes = mr.TextInput(
+    label="Notes",
+    rows=5
+)
+
+notes.value
 ```
 
 ---
@@ -159,6 +177,17 @@ The default is `False`.
 
 ---
 
+### rows
+
+**type:** `int`
+
+Number of visible text rows. The default is `1`.
+
+* `rows=1` renders a single-line input field.
+* `rows` greater than `1` renders a resizable textarea with that many visible lines.
+
+---
+
 ### key
 
 **type:** `string`
@@ -180,4 +209,4 @@ The `key` value is required when widgets are created inside loops.
 * Changes are debounced slightly to avoid excessive updates.
 * `url_key` can be used to initialize the widget from URL query parameters.
 * Empty or whitespace-only URL values are ignored.
-* This widget is intended for **single-line text**. For longer text, consider a textarea-style widget.
+* For longer text, set `rows` to a value greater than `1` to get a resizable textarea.

--- a/mercury/tests/test_text_widget.py
+++ b/mercury/tests/test_text_widget.py
@@ -39,6 +39,35 @@ def test_textinput_passes_disabled_and_hidden_to_widget(monkeypatch):
     assert widget.hidden is True
 
 
+def test_textinput_default_rows_is_single_line():
+    w = TextInputWidget()
+    assert w.rows == 1
+
+
+def test_textinput_passes_rows_to_widget(monkeypatch):
+    monkeypatch.setattr(m, "display", lambda *_: None)
+    WidgetsManager.clear()
+
+    widget = TextInput(label="Notes", rows=5)
+
+    assert widget.rows == 5
+
+
+def test_textinput_rows_must_be_positive():
+    w = TextInputWidget()
+    with pytest.raises(TraitError):
+        w.rows = 0
+
+
+def test_textinput_multiline_renders_textarea():
+    esm = TextInputWidget._esm
+    assert "textarea" in esm
+
+    css = TextInputWidget._css
+    assert "textarea.mljar-textinput-input" in css
+    assert "resize: vertical;" in css
+
+
 def test_textinput_invalid_position_raises_traiterror():
     w = TextInputWidget()
     with pytest.raises(TraitError):

--- a/mercury/text.py
+++ b/mercury/text.py
@@ -22,6 +22,7 @@ def TextInput(
     position: Position = "sidebar",
     disabled: bool = False,
     hidden: bool = False,
+    rows: int = 1,
     key: str = "",
 ):
     """
@@ -47,6 +48,10 @@ def TextInput(
         If `True`, the widget is visible but cannot be interacted with.
     hidden : bool, optional
         If `True`, the widget exists in the UI state but is not rendered.
+    rows : int, optional
+        Number of visible text rows. When greater than `1`, the widget is
+        rendered as a resizable textarea instead of a single-line input.
+        The default is `1`.
     key : str, optional
         Unique identifier used to differentiate widgets with the same parameters.
 
@@ -57,7 +62,7 @@ def TextInput(
     """
     value = resolve_text_value(value=value, url_key=url_key)
 
-    args = [label, value, url_key, position, disabled, hidden]
+    args = [label, value, url_key, position, disabled, hidden, rows]
     kwargs = {
         "label": label,
         "value": value,
@@ -65,6 +70,7 @@ def TextInput(
         "position": position,
         "disabled": disabled,
         "hidden": hidden,
+        "rows": rows,
     }
 
     code_uid = WidgetsManager.get_code_uid("TextInput", key=key, args=args, kwargs=kwargs)
@@ -89,8 +95,15 @@ class TextInputWidget(anywidget.AnyWidget):
       const topLabel = document.createElement("div");
       topLabel.classList.add("mljar-textinput-top-label");
 
-      const input = document.createElement("input");
-      input.type = "text";
+      const rows = model.get("rows") || 1;
+      const multiline = rows > 1;
+
+      const input = document.createElement(multiline ? "textarea" : "input");
+      if (multiline) {
+        input.rows = rows;
+      } else {
+        input.type = "text";
+      }
       input.classList.add("mljar-textinput-input");
 
       container.appendChild(topLabel);
@@ -121,6 +134,11 @@ class TextInputWidget(anywidget.AnyWidget):
       model.on("change:label", syncFromModel);
       model.on("change:disabled", syncFromModel);
       model.on("change:hidden", syncFromModel);
+      model.on("change:rows", () => {
+        if (input.tagName === "TEXTAREA") {
+          input.rows = model.get("rows") || 1;
+        }
+      });
 
       syncFromModel();
 
@@ -197,6 +215,12 @@ class TextInputWidget(anywidget.AnyWidget):
       box-shadow: none;
     }}
 
+    textarea.mljar-textinput-input {{
+      font-family: inherit;
+      font-size: inherit;
+      resize: vertical;
+    }}
+
     .mljar-textinput-input:disabled {{
       background: #f5f5f5;
       color: #888;
@@ -217,6 +241,17 @@ class TextInputWidget(anywidget.AnyWidget):
 
     disabled = traitlets.Bool(False).tag(sync=True)
     hidden = traitlets.Bool(False).tag(sync=True)
+
+    rows = traitlets.Int(
+        default_value=1,
+        help="Number of visible text rows; values above 1 render a textarea",
+    ).tag(sync=True)
+
+    @traitlets.validate("rows")
+    def _validate_rows(self, proposal):
+        if proposal["value"] < 1:
+            raise traitlets.TraitError("rows must be a positive integer")
+        return proposal["value"]
 
     position = traitlets.Enum(
         values=["sidebar", "inline", "bottom"],


### PR DESCRIPTION
Implements #588: `TextInput` gains a `rows` parameter, so it can be extended to a textarea when more than one line is needed.

## Changes

- `mercury/text.py`
  - New `rows: int = 1` parameter on `TextInput()`, passed through to the widget and included in the `WidgetsManager` cache key.
  - New synced `rows` trait on `TextInputWidget`, validated as a positive integer (`TraitError` otherwise).
  - The ESM render creates a `<textarea rows={n}>` when `rows > 1` and keeps the existing `<input type="text">` for `rows=1`; value sync, debounce, disabled, and hidden behavior are unchanged and shared by both elements.
  - CSS: the textarea variant inherits the widget font and is vertically resizable.
- `mercury/tests/test_text_widget.py`: four new tests (default is single line, `rows` passes through `TextInput()`, non-positive `rows` raises `TraitError`, textarea render/CSS present).
- `docs/.../textinput.mdx`: new *Multi-line Text* usage section and `rows` prop documentation; removed the note claiming the widget is single-line only.

## Testing

`python -m pytest mercury/tests/test_text_widget.py` — 15 passed (11 existing + 4 new). The full widget suite (233 tests) also passes.

Usage:
```python
notes = mr.TextInput(label="Notes", rows=5)
```